### PR TITLE
[IBCDPE-457] Improve and document `file` submodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,4 +53,10 @@ repos:
 - repo: https://github.com/kynan/nbstripout
   rev: '0.6.1'
   hooks:
-    - id: nbstripout
+  - id: nbstripout
+
+- repo: https://github.com/econchick/interrogate
+  rev: 1.5.0
+  hooks:
+  - id: interrogate
+    args: [--verbose, --fail-under=25]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,8 @@
 # serve to show the default.
 
 import os
-import sys
 import shutil
+import sys
 
 # -- Path setup --------------------------------------------------------------
 
@@ -72,11 +72,16 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
+
+# Napoleon settings
+napoleon_include_init_with_doc = True
 
 # Enable markdown
 extensions.append("myst_parser")
@@ -94,6 +99,8 @@ myst_enable_extensions = [
     "substitution",
     "tasklist",
 ]
+
+myst_heading_anchors = 3
 
 # The suffix of source filenames.
 source_suffix = [".rst", ".md"]
@@ -171,15 +178,12 @@ todo_emit_warnings = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "sidebar_width": "300px",
-    "page_width": "1200px"
-}
+# html_theme_options = {"sidebar_width": "300px", "page_width": "1200px"}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -299,6 +303,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "setuptools": ("https://setuptools.pypa.io/en/stable/", None),
     "pyscaffold": ("https://pyscaffold.org/en/stable", None),
+    "pyfilesystem": ("https://docs.pyfilesystem.org/en/stable/", None),
 }
 
 print(f"loading configurations for {project} {version} ...", file=sys.stderr)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
-fs~=2.4
-fs~=2.4
 # Requirements file for ReadTheDocs, check .readthedocs.yml.
 # To build the module reference correctly, make sure every external package
 # under `install_requires` in `setup.cfg` is also listed here!
+fs~=2.4
 myst-parser[linkify]
 sphinx>=3.2.1
-sphinx_rtd_theme
-
+sphinx-autodoc-typehints
+sphinx-rtd-theme
 synapseclient~=2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "setuptools.build_meta"
 version_scheme = "no-guess-dev"
 
 [tool.mypy]
+disable_error_code = "type-abstract"
 
 [[tool.mypy.overrides]]
 module = "dcqc"
@@ -24,3 +25,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "dcqc.suites.suites"
 disable_error_code = "assignment"
+
+[tool.interrogate]
+ignore-init-method = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ dev =
     isort~=5.0
     mypy~=0.9
     flake8-pyproject~=1.0
+    sphinx-autodoc-typehints~=1.21
+    interrogate~=1.5
 
 [options.entry_points]
 # Add here console scripts like:

--- a/src/dcqc/__init__.py
+++ b/src/dcqc/__init__.py
@@ -1,4 +1,7 @@
+"""Top-level dcqc module."""
+
 # isort: skip_file
+
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
@@ -15,8 +18,8 @@ from fs.opener import registry
 
 # Import suites to ensure that they are defined and thus discoverable
 # It is located here to avoid a circular import
-from dcqc.suites import suite_abc  # isort: skip
-from dcqc.suites import suites  # isort: skip
+from dcqc.suites import suite_abc
+from dcqc.suites import suites
 
 from dcqc.filesystems.openers import SynapseFSOpener
 from dcqc.filesystems.synapsefs import SynapseFS

--- a/src/dcqc/enums.py
+++ b/src/dcqc/enums.py
@@ -1,8 +1,0 @@
-from enum import Enum
-
-
-class TestStatus(Enum):
-    NONE = "pending"
-    FAIL = "failed"
-    PASS = "passed"
-    SKIP = "skipped"

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -348,7 +348,7 @@ class File(SerializableMixin):
 
         if self.is_url_local():
             local_path = self.get_local_path()
-            destination.symlink_to(local_path)
+            destination.symlink_to(local_path.resolve())
         else:
             with destination.open("wb") as dest_file:
                 self.fs.download(self.fs_path, dest_file)

--- a/src/dcqc/filesystems/remote_file.py
+++ b/src/dcqc/filesystems/remote_file.py
@@ -2,22 +2,10 @@ from __future__ import annotations
 
 import io
 import os
-from array import array
 from collections.abc import Callable, Iterable
-from mmap import mmap
-from pickle import PickleBuffer
-from typing import IO, TYPE_CHECKING, Any, BinaryIO, Optional, Union
+from typing import IO, BinaryIO, Optional
 
 from fs.mode import Mode
-
-if TYPE_CHECKING:
-    from ctypes import _CData
-
-    LinesType = Iterable[
-        Union[
-            bytes, Union[bytearray, memoryview, array[Any], mmap, _CData, PickleBuffer]
-        ]
-    ]
 
 
 class RemoteFile(io.IOBase, BinaryIO):
@@ -101,7 +89,7 @@ class RemoteFile(io.IOBase, BinaryIO):
     def writable(self) -> bool:
         return self.__mode.writing
 
-    def writelines(self, lines: LinesType) -> None:
+    def writelines(self, lines: Iterable[bytes]) -> None:  # type: ignore
         return self._f.writelines(lines)
 
     def read(self, n: int = -1) -> bytes:

--- a/src/dcqc/filesystems/synapsefs.py
+++ b/src/dcqc/filesystems/synapsefs.py
@@ -4,11 +4,11 @@ import os
 import re
 import shutil
 import threading
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
 from tempfile import NamedTemporaryFile, TemporaryDirectory, mkdtemp
-from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Optional, Type
+from typing import Any, BinaryIO, Generator, Optional, Type
 
 from fs import ResourceType
 from fs.base import FS
@@ -35,8 +35,7 @@ from synapseclient.entity import Entity, File, Folder, Project, is_container
 
 from dcqc.filesystems.remote_file import RemoteFile
 
-if TYPE_CHECKING:
-    from fs.info import RawInfo
+RawInfo = Mapping[str, Mapping[str, object]]
 
 
 @contextmanager
@@ -57,18 +56,7 @@ def synapse_errors(path: str) -> Generator:
 
 
 class SynapseFS(FS):
-    """Construct a Synapse filesystem for
-    `PyFilesystem <https://pyfilesystem.org>`_
-
-    Args:
-        root (str, optional): Synapse ID for a project or folder.
-            Defaults to None (rootless mode).
-        auth_token (str, optional): Synapse personal access token.
-            Defaults to None.
-        synapse_args (dict, optional): Dictionary of
-            arguments to pass to the ``Synapse()`` class.
-            Defaults to None.
-    """
+    """A file system-like interface for Synapse."""
 
     NULL_BYTE = b"\x00"
 
@@ -102,6 +90,17 @@ class SynapseFS(FS):
         auth_token: Optional[str] = None,
         synapse_args: Optional[dict[str, Any]] = None,
     ) -> None:
+        """Construct a Synapse filesystem for
+        `PyFilesystem <https://pyfilesystem.org>`_
+
+        Args:
+            root: Synapse ID for a project or folder.
+                Defaults to None (rootless mode).
+            auth_token: Synapse personal access token.
+                Defaults to None.
+            synapse_args: Dictionary of arguments to pass to
+                the ``Synapse`` class. Defaults to None.
+        """
         super(SynapseFS, self).__init__()
         self.auth_token = auth_token
         self.synapse_args = synapse_args or self.DEFAULT_SYNAPSE_ARGS
@@ -335,7 +334,8 @@ class SynapseFS(FS):
         Raises:
             ResourceNotFound: If ``path`` does not exist.
 
-        For more information regarding resource information, see :ref:`info`.
+        For more information regarding resource information,
+            see :ref:`pyfilesystem:info`.
 
         """
         self.validatepath(path)

--- a/src/dcqc/mixins.py
+++ b/src/dcqc/mixins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import asdict
 from pathlib import PurePath
 from typing import Any
@@ -8,7 +7,8 @@ from typing import Any
 SerializedObject = dict[str, Any]
 
 
-class SerializableMixin(ABC):
+# class SerializableMixin(ABC):
+class SerializableMixin:
     @classmethod
     def from_dict_prepare(cls, dictionary: SerializedObject) -> SerializedObject:
         """Validate and prepare dictionary for deserialization."""
@@ -51,14 +51,14 @@ class SerializableMixin(ABC):
         """
         return asdict(self, dict_factory=self.dict_factory)
 
-    @classmethod
-    @abstractmethod
-    def from_dict(cls, dictionary: SerializedObject) -> SerializableMixin:
-        """Deserialize a dictionary into a SerializableMixin object.
+    # @classmethod
+    # @abstractmethod
+    # def from_dict(cls, dictionary: SerializedObject) -> SerializableMixin:
+    #     """Deserialize a dictionary into a SerializableMixin object.
 
-        Args:
-            dictionary: A serialized object.
+    #     Args:
+    #         dictionary: A serialized object.
 
-        Returns:
-            The reconstructed object.
-        """
+    #     Returns:
+    #         The reconstructed object.
+    #     """

--- a/src/dcqc/mixins.py
+++ b/src/dcqc/mixins.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from dataclasses import asdict
+from pathlib import PurePath
 from typing import Any
 
 SerializedObject = dict[str, Any]
@@ -14,11 +18,47 @@ class SerializableMixin(ABC):
             raise ValueError(message)
         return dictionary
 
-    @abstractmethod
-    def to_dict(self) -> SerializedObject:
-        """"""
+    @staticmethod
+    def dict_factory(iterable: list[tuple[str, Any]]) -> dict[str, Any]:
+        """Generate dictionary from dataclass.
 
-    # TODO: Uncomment this once the functions are ready
-    # @abstractmethod
-    # def from_dict(self):
-    #     """"""
+        Unlike the built-in version, this function will
+        handle Path objects. This assumes that the OS
+        will not change between the serialization and
+        deserialization steps.
+
+        Args:
+            iterable: List of attribute name-value pairs.
+
+        Returns:
+            Dictionary of JSON-serializable attributes.
+        """
+        # Ensure that all values are JSON-serializable
+        kwargs = {}
+        for key, value in iterable:
+            if isinstance(value, PurePath):
+                kwargs[key] = str(value)
+            else:
+                kwargs[key] = value
+
+        return dict(**kwargs)
+
+    def to_dict(self) -> SerializedObject:
+        """Serialize the file to a dictionary.
+
+        Returns:
+            A file serialized as a dictionary.
+        """
+        return asdict(self, dict_factory=self.dict_factory)
+
+    @classmethod
+    @abstractmethod
+    def from_dict(cls, dictionary: SerializedObject) -> SerializableMixin:
+        """Deserialize a dictionary into a SerializableMixin object.
+
+        Args:
+            dictionary: A serialized object.
+
+        Returns:
+            The reconstructed object.
+        """

--- a/src/dcqc/parsers.py
+++ b/src/dcqc/parsers.py
@@ -32,7 +32,7 @@ class CsvParser:
             if not file.is_file_local():
                 destination = self.csv_directory / "staged_files" / f"index_{index}"
                 destination.mkdir(parents=True, exist_ok=True)
-                file.stage(destination.as_posix(), overwrite=True)
+                file.stage(destination, overwrite=True)
             yield file
 
     def create_targets(self) -> Iterator[Target]:

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Collection
 from itertools import chain
-from typing import Optional, Type, Union
+from typing import ClassVar, Optional, Type, Union
 
 from dcqc.enums import TestStatus
 from dcqc.file import FileType
@@ -29,9 +29,9 @@ class SuiteABC(SerializableMixin, ABC):
     """
 
     # Class attributes
-    file_type: FileType
-    add_tests: tuple[Type[TestABC], ...]
-    del_tests: tuple[Type[TestABC], ...]
+    file_type: ClassVar[FileType]
+    add_tests: ClassVar[tuple[Type[TestABC], ...]]
+    del_tests: ClassVar[tuple[Type[TestABC], ...]]
 
     # Instance attributes
     type: str

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -5,11 +5,10 @@ from collections.abc import Collection
 from itertools import chain
 from typing import ClassVar, Optional, Type, Union
 
-from dcqc.enums import TestStatus
 from dcqc.file import FileType
 from dcqc.mixins import SerializableMixin, SerializedObject
 from dcqc.target import Target
-from dcqc.tests.test_abc import TestABC
+from dcqc.tests.test_abc import TestABC, TestStatus
 
 
 # TODO: Consider the Composite design pattern once

--- a/src/dcqc/target.py
+++ b/src/dcqc/target.py
@@ -34,7 +34,15 @@ class Target(SerializableMixin):
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, dictionary: dict) -> Target:
+    def from_dict(cls, dictionary: SerializedObject) -> Target:
+        """Deserialize a dictionary into a target.
+
+        Args:
+            dictionary: A serialized target object.
+
+        Returns:
+            The reconstructed target object.
+        """
         dictionary = deepcopy(dictionary)
         dictionary = cls.from_dict_prepare(dictionary)
         files = [File.from_dict(d) for d in dictionary["files"]]

--- a/src/dcqc/target.py
+++ b/src/dcqc/target.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from dcqc.file import File
 from dcqc.mixins import SerializableMixin, SerializedObject
@@ -29,9 +29,6 @@ class Target(SerializableMixin):
     def __init__(self, *files: File):
         self.type = self.__class__.__name__
         self.files = list(files)
-
-    def to_dict(self) -> SerializedObject:
-        return asdict(self)
 
     @classmethod
     def from_dict(cls, dictionary: SerializedObject) -> Target:

--- a/src/dcqc/tests/test_abc.py
+++ b/src/dcqc/tests/test_abc.py
@@ -4,13 +4,20 @@ import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import Optional, Type
+from typing import ClassVar, Optional, Type
 
-from dcqc.enums import TestStatus
 from dcqc.file import File
 from dcqc.mixins import SerializableMixin, SerializedObject
 from dcqc.target import Target
+
+
+class TestStatus(Enum):
+    NONE = "pending"
+    FAIL = "failed"
+    PASS = "passed"
+    SKIP = "skipped"
 
 
 # TODO: Look into the @typing.final decorator
@@ -29,10 +36,10 @@ class TestABC(SerializableMixin, ABC):
     """
 
     # Class attributes
-    tier: int
-    is_external_test: bool
+    tier: ClassVar[int]
+    is_external_test: ClassVar[bool]
     is_external_test = False
-    only_one_file_targets: bool
+    only_one_file_targets: ClassVar[bool]
     only_one_file_targets = True
 
     # Instance attributes
@@ -112,8 +119,11 @@ class ExternalTestMixin(TestABC):
     is_external_test = True
 
     # Class constants
+    STDOUT_PATH: ClassVar[Path]
     STDOUT_PATH = Path("std_out.txt")
+    STDERR_PATH: ClassVar[Path]
     STDERR_PATH = Path("std_err.txt")
+    EXITCODE_PATH: ClassVar[Path]
     EXITCODE_PATH = Path("exit_code.txt")
 
     def compute_status(self) -> TestStatus:

--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -1,8 +1,7 @@
 import hashlib
 
-from dcqc.enums import TestStatus
 from dcqc.file import File
-from dcqc.tests.test_abc import ExternalTestMixin, Process, TestABC
+from dcqc.tests.test_abc import ExternalTestMixin, Process, TestABC, TestStatus
 
 
 class FileExtensionTest(TestABC):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -52,7 +52,8 @@ def test_that_a_local_file_is_symlinked_when_staged_with_a_destination(test_file
     test_file = test_files["good"]
     with TemporaryDirectory() as tmp_dir:
         original_path = Path(test_file.get_local_path())
-        test_file.stage(tmp_dir)
+        tmp_dir_path = Path(tmp_dir)
+        test_file.stage(tmp_dir_path)
         staged_path = Path(test_file.get_local_path())
         assert staged_path.is_symlink()
         assert staged_path.resolve() == original_path.resolve()
@@ -69,7 +70,8 @@ def test_that_a_local_temporary_path_is_created_when_staging_a_remote_file(test_
 def test_that_a_remote_file_is_created_when_staged_with_a_destination(test_files):
     test_file = test_files["synapse"]
     with TemporaryDirectory() as tmp_dir:
-        test_file.stage(tmp_dir)
+        tmp_dir_path = Path(tmp_dir)
+        test_file.stage(tmp_dir_path)
         local_path = test_file.get_local_path()
         assert local_path.exists()
         assert not local_path.is_symlink()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -19,7 +19,7 @@ def test_for_an_error_when_requesting_for_an_unregistered_file_type():
 
 def test_for_an_error_when_retrieving_missing_metadata_on_a_file(test_files):
     test_file = test_files["good"]
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         test_file.get_metadata("foo")
 
 
@@ -35,7 +35,7 @@ def test_that_a_local_file_is_not_moved_when_requesting_a_local_path(test_files)
 @pytest.mark.integration
 def test_for_an_error_when_getting_local_path_for_an_unstaged_remote_file(test_files):
     file = test_files["synapse"]
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         file.get_local_path()
 
 

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -1,11 +1,10 @@
 import pytest
 
-from dcqc.enums import TestStatus
 from dcqc.file import FileType
 from dcqc.suites.suite_abc import SuiteABC
 from dcqc.suites.suites import FileSuite, OmeTiffSuite, TiffSuite
 from dcqc.target import Target
-from dcqc.tests.test_abc import TestABC
+from dcqc.tests.test_abc import TestABC, TestStatus
 from dcqc.tests.tests import LibTiffInfoTest
 
 

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -3,10 +3,9 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from dcqc.enums import TestStatus
 from dcqc.target import Target
 from dcqc.tests import tests
-from dcqc.tests.test_abc import ExternalTestMixin, TestABC
+from dcqc.tests.test_abc import ExternalTestMixin, TestABC, TestStatus
 
 
 def test_that_the_file_extension_test_works_on_correct_files(test_files):


### PR DESCRIPTION
This PR was something I started working on as a side-project, but I ended up building on top of these improvements for IBCDPE-448, so I'm including it here as a PR related to a subtask. Note that I originally intended on filling in docstrings for all submodules, but just doing it for the `file` submodule took a lot of time because I also made improvements to its API. My goal is to progressively fill in docstrings as I work on py-dcqc. 

Here's a summary of the changes introduced here:

- I documented the `file` submodule. 
  - Most of the changes in `file.py` are documentation-related. 
  - I noticed a few low-hanging fruits for improvements.
- New `interrogate` pre-commit hook.
  - This will help maintain "docstring coverage" once we get that percentage up.
  - Note that the minimum allowed is intentionally low to allow the pre-commit hooks to pass. 
  - We will steadily increase this number as we document the package. 
- I made some improvements to how the reference docs are generated
  - I'm not done polishing this process. 
  - The `sphinx_autodoc_typehints` package uses the type hints in the auto-generated docs. 
  - This ensures that the type info isn't duplicated between type hints and the docstrings. 
  - In other words, you no longer have to document the types under `Args:` or `Returns:`.
- I made several tweaks to type hints in general. 
  - These can probably be ignored since they are inconsequential. 
  - Note that the `mypy` pre-commit hook ensures that everything is working as far as typing goes.
- While documenting the `File` class, I noticed that I could improve the way that it used the `SerializableMixin`.
  - Since I like using `Path` objects from `pathlib`, I've added a `dict_factory` function that converts these to strings during the export to dictionaries. 
  - This ensures that the dictionary is indeed JSON-serializable. 
  - This way, I can still use the `dataclass.asdict()` function.
- I discovered `typing.ClassVar` for differentiating class attributes from instance attributes. 
  - This is really handy for dataclasses because type-hinted attributes are automatically used for constructing default magic methods. 
  - By annotating an attribute with `ClassVar`, the `@dataclass` decorator ignores those attributes. 
- I moved the `TestStatus` enum into the `test_abc` submodule. 
  - It looked lonely in the `enum` submodule on its own. 
  - I might change this back if I start accumulating more enums. 