### PR TITLE
Demonstrate implementation for new file types and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - id: autoflake
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY setup.* Pipfile* ./
 COPY src ./src/
 
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAGETASKS=${PKG_VERSION} \
-    python -m pip install .
+    python -m pip install .[all]
 
 CMD [ "python", "-c", "import dcqc" ]

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-dcqc = {editable = true, path = "."}
+dcqc = {editable = true, path = ".", extras = ["qc"]}
 
 [dev-packages]
 dcqc = {editable = true, path = ".", extras = ["testing", "dev"]}

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-dcqc = {editable = true, path = ".", extras = ["qc"]}
+dcqc = {editable = true, path = ".", extras = ["all"]}
 
 [dev-packages]
 dcqc = {editable = true, path = ".", extras = ["testing", "dev"]}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0d7dc0d6eaf114d26ace7be67b886ade99a821308ba874cc3b1951f5e3dcea2d"
+            "sha256": "3b3ccdfe64cc0a36c1bdd34a282172fe7009ed01af11a7951c498171cb3d22d2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -135,6 +135,9 @@
         },
         "dcqc": {
             "editable": true,
+            "extras": [
+                "qc"
+            ],
             "path": "."
         },
         "deprecated": {
@@ -168,6 +171,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==6.0.0"
         },
+        "isodate": {
+            "hashes": [
+                "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+                "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
+            ],
+            "version": "==0.6.1"
+        },
         "keyring": {
             "hashes": [
                 "sha256:17e49fb0d6883c2b4445359434dba95aad84aabb29bbff044ad0ed7100232eca",
@@ -175,6 +185,22 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==23.4.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
+        "rdflib": {
+            "hashes": [
+                "sha256:62dc3c86d1712db0f55785baf8047f63731fa59b2682be03219cb89262065942",
+                "sha256:85c34a86dfc517a41e5f2425a41a0aceacc23983462b32e68610b9fad1383bca"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.2.0"
         },
         "requests": {
             "hashes": [
@@ -571,6 +597,9 @@
         },
         "dcqc": {
             "editable": true,
+            "extras": [
+                "qc"
+            ],
             "path": "."
         },
         "debugpy": {
@@ -627,14 +656,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
-        },
-        "entrypoints": {
-            "hashes": [
-                "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4",
-                "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.4"
         },
         "executing": {
             "hashes": [
@@ -746,11 +767,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:da01e6df1501e6e7c32b5084212ddadd4ee2471602e2cf3e0190f4de6b0ea481",
-                "sha256:f3bf2c08505ad2c3f4ed5c46ae0331a8547d36bf4b21a451e8ae80c0791db95b"
+                "sha256:71618e82e6d59487bea059626e7c79fb4a5b760d1510d02fab1160db6fdfa1f7",
+                "sha256:9c207b0ef2d276d1bfcfeb9a62804336abbe4b170574ea061500952319b1d78c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==8.8.0"
+            "version": "==8.9.0"
         },
         "isort": {
             "hashes": [
@@ -786,11 +807,11 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:214668aaea208195f4c13d28eb272ba79f945fc0cf3f11c7092c20b2ca1980e7",
-                "sha256:52be28e04171f07aed8f20e1616a5a552ab9fee9cbbe6c1896ae170c3880d392"
+                "sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007",
+                "sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==7.4.9"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.0.1"
         },
         "jupyter-core": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3b3ccdfe64cc0a36c1bdd34a282172fe7009ed01af11a7951c498171cb3d22d2"
+            "sha256": "0092b13a8976b6e013fa3a678b61746b2ede8dc6a1619d17bd9e6a4b2473a466"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -136,7 +136,7 @@
         "dcqc": {
             "editable": true,
             "extras": [
-                "qc"
+                "all"
             ],
             "path": "."
         },
@@ -322,11 +322,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-                "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"
+                "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb",
+                "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.11.0"
+            "version": "==3.12.0"
         }
     },
     "develop": {
@@ -598,7 +598,7 @@
         "dcqc": {
             "editable": true,
             "extras": [
-                "qc"
+                "all"
             ],
             "path": "."
         },
@@ -1649,11 +1649,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-                "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"
+                "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb",
+                "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.11.0"
+            "version": "==3.12.0"
         }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,8 +64,8 @@ exclude =
 # `pip install dcqc[PDF]` like:
 # PDF = ReportLab; RXP
 
-# Dependending for quality control
-qc =
+# Additional dependencies for compute tests
+all =
     rdflib
 
 # Dependencies for testing (used by tox and Pipenv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ exclude =
 
 # Additional dependencies for compute tests
 all =
-    rdflib
+    rdflib~=6.2
 
 # Dependencies for testing (used by tox and Pipenv)
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,10 @@ exclude =
 # `pip install dcqc[PDF]` like:
 # PDF = ReportLab; RXP
 
+# Dependending for quality control
+qc =
+    rdflib
+
 # Dependencies for testing (used by tox and Pipenv)
 testing =
     setuptools~=65.0

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -93,8 +93,10 @@ class FileType:
 
 # TODO: These file types could be moved to an external file
 # Instantiated file types are automatically tracked by the FileType class
-FileType("*", ())  # To represent all file types
+FileType("*", (), "format_1915")  # To represent all file types
 FileType("TXT", (".txt",), "format_1964")
+FileType("JSON", (".json",), "format_3464")
+FileType("JSON-LD", (".jsonld",), "format_3749")
 FileType("TIFF", (".tif", ".tiff"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 

--- a/src/dcqc/suites/suites.py
+++ b/src/dcqc/suites/suites.py
@@ -10,6 +10,16 @@ class FileSuite(SuiteABC):
     add_tests = (tests.FileExtensionTest, tests.Md5ChecksumTest)
 
 
+class JsonSuite(FileSuite):
+    file_type = FileType.get_file_type("JSON")
+    add_tests = (tests.JsonLoadTest,)
+
+
+class JsonLdSuite(JsonSuite):
+    file_type = FileType.get_file_type("JSON-LD")
+    add_tests = (tests.JsonLdLoadTest,)
+
+
 class TiffSuite(FileSuite):
     file_type = FileType.get_file_type("TIFF")
     add_tests = (tests.LibTiffInfoTest,)

--- a/src/dcqc/tests/test_abc.py
+++ b/src/dcqc/tests/test_abc.py
@@ -5,7 +5,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import ClassVar, Optional, Type
 
 from dcqc.file import File
@@ -123,6 +125,17 @@ class TestABC(SerializableMixin, ABC):
         test._status = status
 
         return test
+
+    def import_module(self, name: str) -> ModuleType:
+        try:
+            module = import_module(name)
+        except ModuleNotFoundError:
+            message = (
+                f"{self.type} cannot be computed without the '{name}' package. ",
+                "Re-install `dcqc` with the `all` extra: pip install dcqc[all].",
+            )
+            raise ModuleNotFoundError(message)
+        return module
 
 
 @dataclass

--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -1,8 +1,6 @@
 import hashlib
 import json
 
-from rdflib import Graph
-
 from dcqc.file import File
 from dcqc.tests.test_abc import ExternalTestMixin, Process, TestABC, TestStatus
 
@@ -82,10 +80,12 @@ class JsonLdLoadTest(TestABC):
         return status
 
     def _can_be_loaded(self, file: File) -> bool:
+        rdflib = self.import_module("rdflib")
+        graph = rdflib.Graph()
+
         success = True
         local_path = file.get_local_path()
         with local_path.open("r") as infile:
-            graph = Graph()
             try:
                 graph.parse(infile, format="json-ld")
             except Exception:

--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -1,4 +1,7 @@
 import hashlib
+import json
+
+from rdflib import Graph
 
 from dcqc.file import File
 from dcqc.tests.test_abc import ExternalTestMixin, Process, TestABC, TestStatus
@@ -36,11 +39,58 @@ class Md5ChecksumTest(TestABC):
     def _compute_md5_checksum(self, file: File) -> str:
         local_path = file.get_local_path()
         hash_md5 = hashlib.md5()
-        with local_path.open("rb") as f:
-            for chunk in iter(lambda: f.read(4096), b""):
+        with local_path.open("rb") as infile:
+            for chunk in iter(lambda: infile.read(4096), b""):
                 hash_md5.update(chunk)
         actual_md5 = hash_md5.hexdigest()
         return actual_md5
+
+
+class JsonLoadTest(TestABC):
+    tier = 2
+    only_one_file_targets = False
+
+    def compute_status(self) -> TestStatus:
+        status = TestStatus.PASS
+        for file in self.target.files:
+            if not self._can_be_loaded(file):
+                status = TestStatus.FAIL
+                break
+        return status
+
+    def _can_be_loaded(self, file: File) -> bool:
+        success = True
+        local_path = file.get_local_path()
+        with local_path.open("r") as infile:
+            try:
+                json.load(infile)
+            except Exception:
+                success = False
+        return success
+
+
+class JsonLdLoadTest(TestABC):
+    tier = 2
+    only_one_file_targets = False
+
+    def compute_status(self) -> TestStatus:
+        status = TestStatus.PASS
+        for file in self.target.files:
+            if not self._can_be_loaded(file):
+                status = TestStatus.FAIL
+                break
+        return status
+
+    def _can_be_loaded(self, file: File) -> bool:
+        success = True
+        local_path = file.get_local_path()
+        with local_path.open("r") as infile:
+            graph = Graph()
+            try:
+                graph.parse(infile, format="json-ld")
+            except Exception:
+                success = False
+        return success
 
 
 class LibTiffInfoTest(ExternalTestMixin, TestABC):

--- a/tests/data/example.jsonld
+++ b/tests/data/example.jsonld
@@ -1,0 +1,42 @@
+{
+    "@id": "http://store.example.com/",
+    "@type": "Store",
+    "name": "Links Bike Shop",
+    "description": "The most \"linked\" bike store on earth!",
+    "product": [
+        {
+            "@id": "p:links-swift-chain",
+            "@type": "Product",
+            "name": "Links Swift Chain",
+            "description": "A fine chain with many links.",
+            "category": ["cat:parts", "cat:chains"],
+            "price": "10.00",
+            "stock": 10
+        },
+        {
+            "@id": "p:links-speedy-lube",
+            "@type": "Product",
+            "name": "Links Speedy Lube",
+            "description": "Lubricant for your chain links.",
+            "category": ["cat:lube", "cat:chains"],
+            "price": "5.00",
+            "stock": 20
+        }
+    ],
+    "@context": {
+        "Store": "http://ns.example.com/store#Store",
+        "Product": "http://ns.example.com/store#Product",
+        "product": "http://ns.example.com/store#product",
+        "category":
+        {
+          "@id": "http://ns.example.com/store#category",
+          "@type": "@id"
+        },
+        "price": "http://ns.example.com/store#price",
+        "stock": "http://ns.example.com/store#stock",
+        "name": "http://purl.org/dc/terms/title",
+        "description": "http://purl.org/dc/terms/description",
+        "p": "http://store.example.com/products/",
+        "cat": "http://store.example.com/category/"
+    }
+}

--- a/tests/data/files.csv
+++ b/tests/data/files.csv
@@ -4,3 +4,4 @@ test.txt,TIFF,14758f1afd44c09b7992073ccf00b43d
 osfs://test.txt,TXT,definitelynottherightmd5checksum
 syn://syn50555279,TXT,14758f1afd44c09b7992073ccf00b43d
 circuit.tif,TIFF,c7b08f6decb5e7572efbe6074926a843
+example.jsonld,JSON-LD,56bb5f34da6d6df2ade3ac37e25586b7

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ passenv =
     SETUPTOOLS_*
 extras =
     testing
+    all
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
During today's Code Space meeting, I demonstrated how easy it is to implement new tests for new file types. Instead of throwing away that code, I'm opening a PR, which can act as documentation for now if anyone wants to contribute new tests and/or file types. 

Note that I started the `all` "package extra" to capture dependencies needed for running the tests. This way, the basic dependencies are kept minimal. 

```console
pip install dcqc[all]
```

Here's the relevant snippet from the acceptance test report: 

<details>
<summary>JsonLdSuite</summary>
```json
{
  "type": "JsonLdSuite",
  "target": {
    "type": "Target",
    "id": "0006",
    "files": [
      {
        "url": "tests/data/example.jsonld",
        "metadata": {
          "md5_checksum": "56bb5f34da6d6df2ade3ac37e25586b7"
        },
        "type": "JSON-LD",
        "local_path": "tests/data/example.jsonld",
        "name": "example.jsonld"
      }
    ]
  },
  "suite_status": {
    "required_tests": [
      "Md5ChecksumTest"
    ],
    "skipped_tests": [],
    "status": "passed"
  },
  "tests": [
    {
      "type": "JsonLoadTest",
      "tier": 2,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "JsonLdLoadTest",
      "tier": 2,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "Md5ChecksumTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "FileExtensionTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    }
  ]
}
```
</details>