### PR TITLE
Fix docker build script

### DIFF
--- a/src/docker/build.sh
+++ b/src/docker/build.sh
@@ -4,4 +4,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 pipx run --spec 'tox~=3.0' tox -e clean,build
 
-docker build -t dcqc -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}/../.."
+TARBALL_PATH=$(ls dist/*.tar.gz)
+export TARBALL_PATH
+
+docker build \
+    -t dcqc \
+    -f "${SCRIPT_DIR}/Dockerfile" \
+    --build-arg TARBALL_PATH \
+    "${SCRIPT_DIR}/../.."


### PR DESCRIPTION
After adding the `TARBALL_PATH` build argument to the Dockerfile, I forgot to update the associated `build.sh` script to provide a value. 