### PR TITLE
Speed up py-dcqc test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,25 +65,18 @@ jobs:
         - macos-latest
         # TODO: Debug the Windows issues
         # - windows-latest
+    env:
+      OS: ${{ matrix.platform }}
+      PYTHON: ${{ matrix.python }}
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Retrieve pre-built distribution files
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
-      - name: Run tests (without integration tests)
-        if: matrix.platform != 'ubuntu-latest' || matrix.python != '3.11'
-        env:
-          SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
-        run: >-
-          pipx run --spec 'tox~=3.0' tox
-          --installpkg '${{ needs.prepare.outputs.wheel-path }}'
-          -- -rFEx --durations 10 --color yes -m "not integration"
-      - name: Run tests (with integration tests)
-        if: matrix.platform == 'ubuntu-latest' && matrix.python == '3.11'
+      - name: Run tests
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
         run: >-
@@ -92,13 +85,14 @@ jobs:
           -- -rFEx --durations 10 --color yes
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.platform == 'ubuntu-latest' && matrix.python == '3.11'
         with:
-          files: coverage.xml
-          name: ${{ matrix.platform }} - py${{ matrix.python }}
-          verbose: true
           # CodeCov can be flaky, so this step is not required for success
           fail_ci_if_error: false
+          files: coverage.xml
+          # Using matrix pattern from `codecov/codecov-action` README:
+          # https://github.com/codecov/codecov-action#example-workflowyml-with-codecov-action
+          env_vars: OS,PYTHON
+          verbose: true
 
   pypi-publish:
     needs: [prepare, test]

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,7 @@ testpaths =
 # Use pytest markers to select/deselect specific tests
 markers =
     slow: mark tests as slow (deselect with '-m "not slow"')
-    acceptance: mark end-to-end acceptance tests
+    # acceptance: mark end-to-end acceptance tests
 
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,6 +109,7 @@ console_scripts =
 #          Comment those flags to avoid this pytest issue.
 addopts =
     --cov dcqc --cov-report term-missing --cov-report xml
+    -m "not slow"
     --verbose
 norecursedirs =
     dist
@@ -121,9 +122,9 @@ testpaths =
     tests
     demos
 # Use pytest markers to select/deselect specific tests
-# markers =
-#     slow: mark tests as slow (deselect with '-m "not slow"')
-#     system: mark end-to-end system tests
+markers =
+    slow: mark tests as slow (deselect with '-m "not slow"')
+    acceptance: mark end-to-end acceptance tests
 
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,8 +50,8 @@ def get_data():
 
 @pytest.fixture
 def test_files(get_data):
-    txt_path = get_data("test.txt").as_posix()
-    tiff_path = get_data("circuit.tif").as_posix()
+    txt_path = get_data("test.txt")
+    tiff_path = get_data("circuit.tif")
     syn_path = "syn://syn50555279"
     good_metadata = {
         "file_type": "txt",
@@ -66,11 +66,17 @@ def test_files(get_data):
         "md5_checksum": "c7b08f6decb5e7572efbe6074926a843",
     }
     test_files = {
-        "good": File(txt_path, good_metadata),
-        "bad": File(txt_path, bad_metadata),
-        "tiff": File(tiff_path, tiff_metadata),
+        "good": File(txt_path.as_posix(), good_metadata),
+        "bad": File(txt_path.as_posix(), bad_metadata),
+        "tiff": File(tiff_path.as_posix(), tiff_metadata),
         "synapse": File(syn_path, good_metadata),
     }
+
+    # Create an in-memory remote file based on the good file
+    remote_file = File(f"mem://{txt_path.name}", good_metadata)
+    remote_file.fs.writetext(remote_file.fs_path, txt_path.read_text())
+    test_files["remote"] = remote_file
+
     yield test_files
 
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -8,7 +8,8 @@ from dcqc.tests.test_abc import TestABC
 from dcqc.utils import open_parent_fs
 
 
-@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.acceptance
 def test_json_report_generation(get_data):
     # GIVEN a list of external tests to skip (to remain self-contained)
     all_tests = TestABC.list_subclasses()

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -9,7 +9,6 @@ from dcqc.utils import open_parent_fs
 
 
 @pytest.mark.slow
-@pytest.mark.acceptance
 def test_json_report_generation(get_data):
     # GIVEN a list of external tests to skip (to remain self-contained)
     all_tests = TestABC.list_subclasses()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import shutil
+from subprocess import check_output
 from typing import Any
 
 import pytest
@@ -8,96 +9,109 @@ from typer.testing import CliRunner
 from dcqc.main import app
 
 
-# Using a test class to mark all tests as "integration"
-@pytest.mark.integration
-class TestCLI:
-    def run_command(self, arguments: list[Any]):
-        runner = CliRunner()
-        str_arguments = [str(arg) for arg in arguments]
-        result = runner.invoke(app, str_arguments)
-        return result
+def run_command(arguments: list[Any]):
+    runner = CliRunner()
+    str_arguments = [str(arg) for arg in arguments]
+    result = runner.invoke(app, str_arguments)
+    return result
 
-    def check_command_result(self, result: Result):
-        assert result.exit_code == 0
 
-    def test_create_targets(self, get_data, get_output):
-        input_csv = get_data("small.csv")
-        output_dir = get_output("create_targets")
-        shutil.rmtree(output_dir, ignore_errors=True)
+def check_command_result(result: Result):
+    assert result.exit_code == 0
 
-        assert not output_dir.exists()
-        args = ["create-targets", input_csv, output_dir]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert len(list(output_dir.iterdir())) > 0
 
-    def test_stage_target(self, get_data, get_output):
-        input_json = get_data("target.json")
-        output_json = get_output("stage_target/target.staged.json")
-        output_dir = get_output("stage_target/targets")
-        output_json.unlink(missing_ok=True)
-        shutil.rmtree(output_dir, ignore_errors=True)
+@pytest.mark.slow
+def test_that_the_module_cli_behaves_the_same_as_the_plain_cli():
+    module_cli = check_output(["python", "-m", "dcqc", "--help"])
+    plain_cli = check_output(["dcqc", "--help"])
+    assert module_cli == plain_cli
 
-        assert not output_dir.exists()
-        args = ["stage-target", "-prt", ".", input_json, output_json, output_dir]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert len(list(output_dir.iterdir())) > 0
 
-    def test_create_tests(self, get_data, get_output):
-        input_json = get_data("target.json")
-        output_dir = get_output("create_tests")
-        shutil.rmtree(output_dir, ignore_errors=True)
+def test_create_targets(get_data, get_output):
+    input_csv = get_data("small.csv")
+    output_dir = get_output("create_targets")
+    shutil.rmtree(output_dir, ignore_errors=True)
 
-        assert not output_dir.exists()
-        args = ["create-tests", "-rt", "Md5ChecksumTest", input_json, output_dir]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert len(list(output_dir.iterdir())) > 0
+    assert not output_dir.exists()
+    args = ["create-targets", input_csv, output_dir]
+    result = run_command(args)
+    check_command_result(result)
+    assert len(list(output_dir.iterdir())) > 0
 
-    def test_create_process(self, get_data, get_output):
-        input_json = get_data("test.external.json")
-        output_path = get_output("create_process") / "process.json"
-        output_path.unlink(missing_ok=True)
 
-        assert not output_path.exists()
-        args = ["create-process", input_json, output_path]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert output_path.exists()
+def test_stage_target(get_data, get_output):
+    input_json = get_data("target.json")
+    output_json = get_output("stage_target/target.staged.json")
+    output_dir = get_output("stage_target/targets")
+    output_json.unlink(missing_ok=True)
+    shutil.rmtree(output_dir, ignore_errors=True)
 
-    def test_compute_test(self, get_data, get_output):
-        input_json = get_data("test.internal.json")
-        output_path = get_output("compute_test") / "test.json"
-        output_path.unlink(missing_ok=True)
+    assert not output_dir.exists()
+    args = ["stage-target", "-prt", ".", input_json, output_json, output_dir]
+    result = run_command(args)
+    check_command_result(result)
+    assert len(list(output_dir.iterdir())) > 0
 
-        assert not output_path.exists()
-        args = ["compute-test", input_json, output_path]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert output_path.exists()
 
-    def test_create_suite(self, get_data, get_output):
-        input_json = get_data("test.computed.json")
-        output_path = get_output("create_suite") / "suite.json"
-        output_path.unlink(missing_ok=True)
+def test_create_tests(get_data, get_output):
+    input_json = get_data("target.json")
+    output_dir = get_output("create_tests")
+    shutil.rmtree(output_dir, ignore_errors=True)
 
-        args = ["create-suite", output_path, input_json, input_json, input_json]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert output_path.exists()
+    assert not output_dir.exists()
+    args = ["create-tests", "-rt", "Md5ChecksumTest", input_json, output_dir]
+    result = run_command(args)
+    check_command_result(result)
+    assert len(list(output_dir.iterdir())) > 0
 
-    def test_combine_suites(self, get_data, get_output):
-        input_json = get_data("suite.json")
-        output_path = get_output("combine_suites") / "suites.json"
-        output_path.unlink(missing_ok=True)
 
-        args = ["combine-suites", output_path, input_json, input_json, input_json]
-        result = self.run_command(args)
-        self.check_command_result(result)
-        assert output_path.exists()
+def test_create_process(get_data, get_output):
+    input_json = get_data("test.external.json")
+    output_path = get_output("create_process") / "process.json"
+    output_path.unlink(missing_ok=True)
 
-    def test_list_tests(self):
-        args = ["list-tests"]
-        result = self.run_command(args)
-        self.check_command_result(result)
+    assert not output_path.exists()
+    args = ["create-process", input_json, output_path]
+    result = run_command(args)
+    check_command_result(result)
+    assert output_path.exists()
+
+
+def test_compute_test(get_data, get_output):
+    input_json = get_data("test.internal.json")
+    output_path = get_output("compute_test") / "test.json"
+    output_path.unlink(missing_ok=True)
+
+    assert not output_path.exists()
+    args = ["compute-test", input_json, output_path]
+    result = run_command(args)
+    check_command_result(result)
+    assert output_path.exists()
+
+
+def test_create_suite(get_data, get_output):
+    input_json = get_data("test.computed.json")
+    output_path = get_output("create_suite") / "suite.json"
+    output_path.unlink(missing_ok=True)
+
+    args = ["create-suite", output_path, input_json, input_json, input_json]
+    result = run_command(args)
+    check_command_result(result)
+    assert output_path.exists()
+
+
+def test_combine_suites(get_data, get_output):
+    input_json = get_data("suite.json")
+    output_path = get_output("combine_suites") / "suites.json"
+    output_path.unlink(missing_ok=True)
+
+    args = ["combine-suites", output_path, input_json, input_json, input_json]
+    result = run_command(args)
+    check_command_result(result)
+    assert output_path.exists()
+
+
+def test_list_tests():
+    args = ["list-tests"]
+    result = run_command(args)
+    check_command_result(result)

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -16,21 +16,19 @@ def test_that_the_file_extension_test_works_on_correct_files(test_files):
     assert test_status == TestStatus.PASS
 
 
-@pytest.mark.integration
 def test_that_the_file_extension_test_works_on_correct_remote_file(test_files):
-    good_file = test_files["synapse"]
-    target = Target(good_file)
+    remote_file = test_files["remote"]
+    target = Target(remote_file)
     test = tests.FileExtensionTest(target)
     test_status = test.get_status()
     assert test_status == TestStatus.PASS
 
 
-# @pytest.mark.integration
-# def test_that_a_tiff_file_with_good_extensions_is_passed():
-#     file = File("syn://syn50944306", {"file_type": "TIFF"})
-#     target = Target(file)
-#     test = tests.FileExtensionTest(target)
-#     assert test.get_status() == TestStatus.PASS
+def test_that_a_tiff_file_with_good_extensions_is_passed(test_files):
+    file = test_files["tiff"]
+    target = Target(file)
+    test = tests.FileExtensionTest(target)
+    assert test.get_status() == TestStatus.PASS
 
 
 def test_that_the_file_extension_test_works_on_incorrect_files(test_files):

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ extras =
     testing
     all
 commands =
-    pytest {posargs}
+    # The `-m ""` overrides the `-m "not slow"` in setup.cfg
+    pytest {posargs} -m ""
 
 
 [testenv:lint]


### PR DESCRIPTION
One of the major motivations for #13 is that the test suite would be much faster without the `SynapseFS` tests. This PR takes advantage of the fact that the tests are now relatively fast. For example, there's no need to limit which tests are run on different Python versions and operating systems. I'm now running all tests on all combinations in the `ci.yml` workflow. 

I also took the opportunity to clean up the pytest marks based on Tom's feedback a few PRs back. I now just have a `slow` mark, which is enforced by the `markers` section in `setup.cfg`. Currently, all of my tests take less than 0.03 seconds except for the large acceptance test (which interacts with Synapse) and a CLI test (which spawns two subprocesses). For now, both of these fall under my definition of slow because I like my tests to be almost instant. I also think that the 0.42s CLI test isn't critical enough to include in all local test runs (but it's worth including in the full test suite in `ci.yml`). 

I've set up `pytest` to exclude slow tests by default, but `tox` is configured to override this to include all tests, which is what's used during CI testing. You can also re-include the slow tests by eliminating the mark filter with `pytest -m ""`. 

Aside from that, I added a `remote` entry to the `test_files` fixture. I found a way to create a "remote file" in-memory for much faster tests compared to using Synapse. No mocking was needed! You'll see `test_files["remote"]` a few times, which was me replacing calls to Synapse to in-memory operations. 

I also removed the `TestCLI` class since the only reason it existed was to mark all included tests as `integration`, but I've now removed that mark, so there's no need for a class anymore. Like I mentioned before, I did label one of these tests with `@pytest.mark.slow`. 

```
14.74s call     tests/test_acceptance.py::test_json_report_generation
0.42s call     tests/test_main.py::test_that_the_module_cli_behaves_the_same_as_the_plain_cli
0.02s call     tests/test_main.py::test_create_targets
0.01s call     tests/test_main.py::test_combine_suites
0.01s call     tests/test_main.py::test_create_suite
```