### PR TITLE
Revamp the way that local paths are handled by the `File` class

### DIFF
--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -35,7 +35,7 @@ class Md5ChecksumTest(TestABC):
         return status
 
     def _compute_md5_checksum(self, file: File) -> str:
-        local_path = file.get_local_path()
+        local_path = file.local_path
         hash_md5 = hashlib.md5()
         with local_path.open("rb") as infile:
             for chunk in iter(lambda: infile.read(4096), b""):
@@ -58,7 +58,7 @@ class JsonLoadTest(TestABC):
 
     def _can_be_loaded(self, file: File) -> bool:
         success = True
-        local_path = file.get_local_path()
+        local_path = file.local_path
         with local_path.open("r") as infile:
             try:
                 json.load(infile)
@@ -84,7 +84,7 @@ class JsonLdLoadTest(TestABC):
         graph = rdflib.Graph()
 
         success = True
-        local_path = file.get_local_path()
+        local_path = file.local_path
         with local_path.open("r") as infile:
             try:
                 graph.parse(infile, format="json-ld")
@@ -98,7 +98,7 @@ class LibTiffInfoTest(ExternalTestMixin, TestABC):
 
     def generate_process(self) -> Process:
         file = self._get_single_target_file()
-        path = file.get_local_path().as_posix()
+        path = file.local_path.as_posix()
         command_args = ["tiffinfo", path]
         process = Process(
             container="quay.io/brunograndephd/libtiff:2.0",
@@ -112,7 +112,7 @@ class BioFormatsInfoTest(ExternalTestMixin, TestABC):
 
     def generate_process(self) -> Process:
         file = self._get_single_target_file()
-        path = file.get_local_path().as_posix()
+        path = file.local_path.as_posix()
         command_args = [
             "/opt/bftools/showinf",
             "-nopix",
@@ -132,7 +132,7 @@ class OmeXmlSchemaTest(ExternalTestMixin, TestABC):
 
     def generate_process(self) -> Process:
         file = self._get_single_target_file()
-        path = file.get_local_path().as_posix()
+        path = file.local_path.as_posix()
         command_args = [
             "/opt/bftools/xmlvalid",
             path,


### PR DESCRIPTION
This change was prompted by work at closing the code coverage gap for the `file` submodule. I decided to drop the `get_local_path()` method in favor of a Python property like `name`. 

Since I wanted the local path to be included in the serialized `File` JSON output, I wanted to generalized what I had started with the `name` property. That's what motived the `_serialized_properties` class attribute. If you want a property to appear in the output JSON, you should list it in `_serialized_properties` and the `SerializableMixin` will handle the rest. This allowed me to remove the `File`-specific `to_dict()` implementation. 

The changes to the tests are mostly to use this new API (`file.local_path` instead of `file.get_local_path()`) as well as additional tests to close the test coverage gap. The `file` submodule is now 100% covered. 

```
---------- coverage: platform darwin, python 3.11.1-final-0 ----------
Name                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------
src/dcqc/__init__.py               9      0      0      0   100%
src/dcqc/__main__.py               2      0      0      0   100%
src/dcqc/file.py                 160      0     54      0   100%
src/dcqc/main.py                  99      2     34      2    97%   44-45, 56->60
src/dcqc/mixins.py                70      4     36      3    93%   34-35, 41, 63
src/dcqc/parsers.py              100     21     46      6    77%   43-45, 74-76, 89, 97-98, 103-104, 116-117, 125-134
src/dcqc/reports.py               75      9     22      2    89%   24->27, 36-38, 40-41, 64, 68, 82, 88
src/dcqc/suites/__init__.py        0      0      0      0   100%
src/dcqc/suites/suite_abc.py     164      3     67      2    98%   119, 125-126
src/dcqc/suites/suites.py         18      0      0      0   100%
src/dcqc/target.py                43      1     12      1    96%   64
src/dcqc/tests/__init__.py         0      0      0      0   100%
src/dcqc/tests/test_abc.py       127      9     30      0    94%   63, 132-137, 167-171
src/dcqc/tests/tests.py          100      8     25      2    92%   55-56, 65-66, 78-79, 91-92
src/dcqc/utils.py                 20      0      6      0   100%
--------------------------------------------------------------------------
TOTAL                            987     57    332     18    94%
```