### PR TITLE
Close code coverage gaps with `main`, `target`, and `mixins`

### DIFF
--- a/src/dcqc/main.py
+++ b/src/dcqc/main.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from csv import DictWriter
 from pathlib import Path
@@ -13,7 +12,6 @@ from dcqc.reports import JsonReport
 from dcqc.suites.suite_abc import SuiteABC
 from dcqc.target import Target
 from dcqc.tests.test_abc import ExternalTestMixin, TestABC
-from dcqc.utils import is_url_local
 
 # Make commands optional to allow for `dcqc --version`
 app = Typer(invoke_without_command=True)
@@ -48,14 +46,12 @@ def main(version: bool = False):
 @app.command()
 def create_targets(
     input_csv: Path = input_path_arg,
-    output_dir: str = output_dir_arg,
+    output_dir: Path = output_dir_path_arg,
     overwrite: bool = overwrite_opt,
     stage_files: bool = stage_files_opt,
 ):
     """Create target JSON files from a targets CSV file"""
-    if is_url_local(output_dir):
-        _, _, resource = output_dir.rpartition("://")
-        os.makedirs(resource, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     parser = CsvParser(input_csv, stage_files)
     targets = parser.create_targets()
@@ -64,7 +60,7 @@ def create_targets(
     named_targets = {f"target-{target.id}.json": target for target in targets}
 
     report = JsonReport()
-    report.save_many(named_targets, output_dir, overwrite)
+    report.save_many(named_targets, output_dir.as_posix(), overwrite)
 
 
 @app.command()

--- a/src/dcqc/mixins.py
+++ b/src/dcqc/mixins.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import fields
 from itertools import chain
 from pathlib import Path, PurePath
 from typing import Any, ClassVar, Optional, TypeVar, cast
@@ -30,7 +30,7 @@ class SerializableMixin(ABC):
 
     # TODO: Move this logic to JsonReport as a JSONEncoder subclass
     def serialize_paths_relative_to(self, location: Optional[Path]):
-        if location is not None and not location.exists() and location.is_dir():
+        if location is not None and not (location.exists() and location.is_dir()):
             message = f"Location ({location}) is not an existing directory."
             raise ValueError(message)
         self._serialize_paths_relative_to = location
@@ -59,8 +59,6 @@ class SerializableMixin(ABC):
             result = self.serialize_path(value)
         elif isinstance(value, SerializableMixin):
             result = value.to_dict()
-        elif is_dataclass(value):
-            result = asdict(value)
         elif isinstance(value, Mapping):
             result = {key: self.serialize_value(val) for key, val in value.items()}
         elif isinstance(value, Iterable):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,15 +26,16 @@ OUTDIR.mkdir(exist_ok=True)
 UUID = str(uuid4())
 USER = getuser()
 UTCTIME = datetime.now().isoformat(" ", "seconds").replace(":", ".")
-RUNID = f"{USER} - {UTCTIME} - {UUID}"  # Valid characters: [A-Za-z0-9 .+'()_-]
+RUN_ID = f"{USER} - {UTCTIME} - {UUID}"  # Valid characters: [A-Za-z0-9 .+'()_-]
 
 
 # Track the list of output files to avoid clashes between tests
 outputs = set()
 
 
-def pytest_configure():
-    pytest.RUNID = RUNID  # type: ignore
+@pytest.fixture
+def run_id():
+    return RUN_ID
 
 
 @pytest.fixture

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -126,3 +126,35 @@ def test_that_an_unset_local_path_is_ignored_during_deserialization(test_files):
     file_from_dict = File.from_dict(dictionary)
     with pytest.raises(FileNotFoundError):
         file_from_dict.local_path
+
+
+def test_that_a_file_cannot_be_made_relative_to_a_nonexistent_directory(test_files):
+    file = test_files["good"]
+    nonexistent_dir = Path("foobar")
+    with pytest.raises(ValueError):
+        file.serialize_paths_relative_to(nonexistent_dir)
+
+
+def test_that_a_file_cannot_be_made_relative_to_a_another_file(test_files):
+    file = test_files["good"]
+    another_file = test_files["bad"]
+    another_file_path = another_file.local_path
+    with pytest.raises(ValueError):
+        file.serialize_paths_relative_to(another_file_path)
+
+
+def test_that_paths_are_unchanged_when_not_using_serialize_paths_relative_to():
+    path = Path("foobar")
+    file = File("test.txt", local_path=path)
+    file_dict = file.to_dict()
+    assert file_dict["local_path"] == str(path)
+
+
+def test_that_paths_change_when_using_serialize_paths_relative_to(get_output):
+    path = Path("foo")
+    relative_to = get_output("relative-to")
+    relative_to.mkdir(parents=True, exist_ok=True)
+    file = File("test.txt", local_path=path)
+    file.serialize_paths_relative_to(relative_to)
+    file_dict = file.to_dict()
+    assert file_dict["local_path"] != str(path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import Result
 from typer.testing import CliRunner
 
+import dcqc
 from dcqc.main import app
 
 
@@ -25,6 +26,13 @@ def test_that_the_module_cli_behaves_the_same_as_the_plain_cli():
     module_cli = check_output(["python", "-m", "dcqc", "--help"])
     plain_cli = check_output(["dcqc", "--help"])
     assert module_cli == plain_cli
+
+
+def test_that_the_package_version_can_be_printed():
+    args = ["--version"]
+    result = run_command(args)
+    check_command_result(result)
+    assert dcqc.__version__ in result.output
 
 
 def test_create_targets(get_data, get_output):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -20,3 +20,10 @@ def test_for_an_error_when_restoring_a_target_with_a_discordant_type(test_files)
     target_1_dict["type"] = "UnexpectedQcTarget"
     with pytest.raises(ValueError):
         Target.from_dict(target_1_dict)
+
+
+def test_for_an_error_when_accessing_the_file_type_for_a_multifile_target(test_files):
+    file = test_files["good"]
+    target = Target(file, file)
+    with pytest.raises(NotImplementedError):
+        target.get_file_type()


### PR DESCRIPTION
This PR continue my work at closing gaps in code coverage. This one tackles the `main`, `target`, and `mixins` submodules, which are now at 100% coverage. For transparency, the change in `create_targets()` was because the if statement wasn't going to be used by Nextflow, so I got rid of it for now in the spirit of YAGNI. Same with the removal of the `is_dataclass()` entry in the if-else block. 

**Edit:** I noticed that the acceptance test is at risk of failing due to concurrent tests trying to upload to the same file. I've used the approach I created for `SynapseFS` testing to create test run-specific folders on Synapse. Note that I'm using the `fs` package instead of `synapseclient` to remain agnostic of the backend. 

```
---------- coverage: platform darwin, python 3.11.1-final-0 ----------
Name                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------
src/dcqc/__init__.py               9      0      0      0   100%
src/dcqc/__main__.py               2      0      0      0   100%
src/dcqc/file.py                 160      0     54      0   100%
src/dcqc/main.py                  97      0     32      0   100%
src/dcqc/mixins.py                68      0     34      0   100%
src/dcqc/parsers.py              100     21     46      6    77%   43-45, 74-76, 89, 97-98, 103-104, 116-117, 125-134
src/dcqc/reports.py               75      9     22      2    89%   24->27, 36-38, 40-41, 64, 68, 82, 88
src/dcqc/suites/__init__.py        0      0      0      0   100%
src/dcqc/suites/suite_abc.py     164      3     67      2    98%   119, 125-126
src/dcqc/suites/suites.py         18      0      0      0   100%
src/dcqc/target.py                43      0     12      0   100%
src/dcqc/tests/__init__.py         0      0      0      0   100%
src/dcqc/tests/test_abc.py       127      9     30      0    94%   63, 132-137, 167-171
src/dcqc/tests/tests.py          100      8     25      2    92%   55-56, 65-66, 78-79, 91-92
src/dcqc/utils.py                 20      0      6      0   100%
--------------------------------------------------------------------------
TOTAL                            983     50    328     12    95%
```