### PR TITLE
Close code coverage for `suites` and `tests` submodules

### DIFF
--- a/src/dcqc/mixins.py
+++ b/src/dcqc/mixins.py
@@ -108,6 +108,7 @@ class SerializableMixin(ABC):
         return self.dict_factory(result)
 
     # TODO: Use template method to handle `_serialized_properties`
+    #       as well as `deepcopy()`
     @classmethod
     @abstractmethod
     def from_dict(cls, dictionary: SerializedObject) -> SerializableMixin:

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -216,6 +216,10 @@ class SuiteABC(SerializableMixin, ABC):
             return registry["*"]
         return registry[name]
 
+    @property
+    def tests_by_name(self):
+        return {test.type: test for test in self.tests}
+
     def compute_tests(self) -> None:
         """Compute the status for each initialized test."""
         self.target.stage()

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -51,7 +51,9 @@ class SuiteABC(SerializableMixin, ABC):
         test_classes = self.list_test_classes()
         test_names = set(test.__name__ for test in test_classes)
 
-        required_tests = required_tests or self._default_required_tests()
+        # To differentiate between None and []
+        if required_tests is None:
+            required_tests = self._default_required_tests()
         self.required_tests = set(required_tests).intersection(test_names)
 
         skipped_tests = skipped_tests or list()
@@ -229,8 +231,9 @@ class SuiteABC(SerializableMixin, ABC):
     def compute_status(self) -> TestStatus:
         """Compute the overall suite status."""
         self.compute_tests()
-        if self._status is not TestStatus.NONE:
+        if self._status != TestStatus.NONE:
             return self._status
+        self._status = TestStatus.PASS
         for test in self.tests:
             test_name = test.type
             if test_name not in self.required_tests:

--- a/src/dcqc/tests/test_abc.py
+++ b/src/dcqc/tests/test_abc.py
@@ -62,9 +62,9 @@ class TestABC(SerializableMixin, ABC):
         """Force the test to be skipped."""
         self._status = TestStatus.SKIP
 
-    def get_status(self) -> TestStatus:
+    def get_status(self, compute_ok: bool = True) -> TestStatus:
         """Compute (if applicable) and return the test status."""
-        if self._status == TestStatus.NONE:
+        if self._status == TestStatus.NONE and compute_ok:
             self._status = self.compute_status()
         return self._status
 

--- a/src/dcqc/tests/test_abc.py
+++ b/src/dcqc/tests/test_abc.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import InitVar, dataclass
 from enum import Enum
 from importlib import import_module
 from pathlib import Path
@@ -141,18 +142,18 @@ class TestABC(SerializableMixin, ABC):
 @dataclass
 class Process(SerializableMixin):
     container: str
-    command_args: Sequence[str]
+    command_args: InitVar[Sequence[str]]
     cpus: int = 1
     memory: int = 2  # In GB
 
-    def get_command(self) -> str:
-        return shlex.join(self.command_args)
+    _serialized_properties = ["command"]
 
-    def to_dict(self):
-        dictionary = super(Process, self).to_dict()
-        del dictionary["command_args"]
-        dictionary["command"] = self.get_command()
-        return dictionary
+    def __post_init__(self, command_args: Sequence[str]):
+        self._command_args = command_args
+
+    @property
+    def command(self) -> str:
+        return shlex.join(self._command_args)
 
     @classmethod
     def from_dict(cls, dictionary: SerializedObject) -> Process:
@@ -164,6 +165,7 @@ class Process(SerializableMixin):
         Returns:
             The reconstructed process object.
         """
+        dictionary = deepcopy(dictionary)
         command = dictionary.pop("command")
         command_args = shlex.split(command)
         dictionary["command_args"] = command_args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ from uuid import uuid4
 import pytest
 
 from dcqc.file import File
+from dcqc.suites.suite_abc import SuiteABC
+from dcqc.target import Target
 
 CNFPATH = Path(__file__).resolve()
 TESTDIR = CNFPATH.parent
@@ -79,6 +81,22 @@ def test_files(get_data):
     test_files["remote"] = remote_file
 
     yield test_files
+
+
+@pytest.fixture
+def test_targets(test_files):
+    test_targets = dict()
+    for name, file in test_files.items():
+        test_targets[name] = Target(file)
+    yield test_targets
+
+
+@pytest.fixture
+def test_suites(test_targets):
+    test_suites = dict()
+    for name, target in test_targets.items():
+        test_suites[name] = SuiteABC.from_target(target)
+    yield test_suites
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def get_data():
 @pytest.fixture
 def test_files(get_data):
     txt_path = get_data("test.txt")
+    jsonld_path = get_data("example.jsonld")
     tiff_path = get_data("circuit.tif")
     syn_path = "syn://syn50555279"
     good_metadata = {
@@ -64,6 +65,10 @@ def test_files(get_data):
         "file_type": "tiff",
         "md5_checksum": "definitelynottherightmd5checksum",
     }
+    jsonld_metadata = {
+        "file_type": "JSON-LD",
+        "md5_checksum": "56bb5f34da6d6df2ade3ac37e25586b7",
+    }
     tiff_metadata = {
         "file_type": "tiff",
         "md5_checksum": "c7b08f6decb5e7572efbe6074926a843",
@@ -72,6 +77,7 @@ def test_files(get_data):
         "good": File(txt_path.as_posix(), good_metadata),
         "bad": File(txt_path.as_posix(), bad_metadata),
         "tiff": File(tiff_path.as_posix(), tiff_metadata),
+        "jsonld": File(jsonld_path.as_posix(), jsonld_metadata),
         "synapse": File(syn_path, good_metadata),
     }
 

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -3,16 +3,16 @@ import pytest
 from dcqc.file import FileType
 from dcqc.suites.suite_abc import SuiteABC
 from dcqc.suites.suites import FileSuite, OmeTiffSuite, TiffSuite
-from dcqc.target import Target
 from dcqc.tests.test_abc import TestABC, TestStatus
-from dcqc.tests.tests import LibTiffInfoTest
+from dcqc.tests.tests import FileExtensionTest, LibTiffInfoTest
+
+FileType("None", ())
+FileType("Unpaired", ())
 
 
 class RedundantFileSuite(TiffSuite):
+    file_type = FileType.get_file_type("None")
     del_tests = (LibTiffInfoTest,)
-
-
-FileType("Unpaired", ())
 
 
 class DummyTest(TestABC):
@@ -69,8 +69,26 @@ def test_that_the_generic_file_suite_is_retrieved_for_an_unpaired_file_type():
     assert actual is FileSuite
 
 
-def test_that_the_default_required_tests_are_only_tiers_1_and_2(test_files):
-    tiff_file = test_files["tiff"]
-    tiff_target = Target(tiff_file)
-    tiff_suite = TiffSuite(tiff_target)
-    assert all(test.tier <= 2 for test in tiff_suite.tests)
+def test_that_the_default_required_tests_are_only_tiers_1_and_2(test_suites):
+    suite = test_suites["tiff"]
+    assert all(test.tier <= 2 for test in suite.tests)
+
+
+def test_that_skipped_tests_are_skipped_when_building_suite_from_tests(test_suites):
+    suite = test_suites["tiff"]
+    tests = suite.tests
+    new_suite = SuiteABC.from_tests(tests, skipped_tests=["LibTiffInfoTest"])
+    skipped_test_before = suite.tests_by_name["LibTiffInfoTest"]
+    skipped_test_after = new_suite.tests_by_name["LibTiffInfoTest"]
+    assert skipped_test_before.get_status(compute_ok=False) != TestStatus.SKIP
+    assert skipped_test_after.get_status(compute_ok=False) == TestStatus.SKIP
+
+
+def test_for_an_error_when_building_suite_from_tests_with_diff_targets(test_targets):
+    target_1 = test_targets["good"]
+    target_2 = test_targets["bad"]
+    test_1 = FileExtensionTest(target_1)
+    test_2 = FileExtensionTest(target_2)
+    tests = [test_1, test_2]
+    with pytest.raises(ValueError):
+        SuiteABC.from_tests(tests)

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -92,3 +92,29 @@ def test_for_an_error_when_building_suite_from_tests_with_diff_targets(test_targ
     tests = [test_1, test_2]
     with pytest.raises(ValueError):
         SuiteABC.from_tests(tests)
+
+
+def test_that_a_suite_will_not_consider_unrequired_tests(test_targets):
+    target = test_targets["bad"]
+    required_tests = []
+    skipped_tests = ["LibTiffInfoTest"]
+    suite = SuiteABC.from_target(target, required_tests, skipped_tests)
+    suite_status = suite.compute_status()
+    assert suite_status == TestStatus.PASS
+
+
+def test_that_a_suite_will_consider_required_tests_when_failing(test_targets):
+    target = test_targets["bad"]
+    required_tests = ["FileExtensionTest"]
+    skipped_tests = ["LibTiffInfoTest"]
+    suite = SuiteABC.from_target(target, required_tests, skipped_tests)
+    suite_status = suite.compute_status()
+    assert suite_status == TestStatus.FAIL
+
+
+def test_that_a_suite_will_consider_required_tests_when_passing(test_targets):
+    target = test_targets["good"]
+    required_tests = ["Md5ChecksumTest"]
+    suite = SuiteABC.from_target(target, required_tests)
+    suite_status = suite.compute_status()
+    assert suite_status == TestStatus.PASS


### PR DESCRIPTION
Similar to #18, I'm working on closing any gaps in test coverage. This PR focuses on the gaps in the `tests` and `suites` submodules. You'll also notice that I created some pytest fixtures to reduce some repetition.

```
---------- coverage: platform darwin, python 3.11.1-final-0 ----------
Name                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------
src/dcqc/__init__.py               9      0      0      0   100%
src/dcqc/__main__.py               2      0      0      0   100%
src/dcqc/file.py                 160      0     54      0   100%
src/dcqc/main.py                  95      0     32      0   100%
src/dcqc/mixins.py                68      0     34      0   100%
src/dcqc/parsers.py              100     21     46      6    77%   43-45, 74-76, 89, 97-98, 103-104, 116-117, 125-134
src/dcqc/reports.py               75      9     22      2    89%   24->27, 36-38, 40-41, 64, 68, 82, 88
src/dcqc/suites/__init__.py        0      0      0      0   100%
src/dcqc/suites/suite_abc.py     169      0     73      0   100%
src/dcqc/suites/suites.py         18      0      0      0   100%
src/dcqc/target.py                43      0     12      0   100%
src/dcqc/tests/__init__.py         0      0      0      0   100%
src/dcqc/tests/test_abc.py       128      0     32      0   100%
src/dcqc/tests/tests.py          100      0     25      0   100%
src/dcqc/utils.py                 20      0      6      0   100%
--------------------------------------------------------------------------
TOTAL                            987     30    336      8    97%
```