### PR TITLE
Close code coverage for `parsers` and `reports` submodules

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -665,6 +665,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
         },
+        "execnet": {
+            "hashes": [
+                "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5",
+                "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.9.0"
+        },
         "executing": {
             "hashes": [
                 "sha256:0314a69e37426e3608aada02473b4161d4caf5a4b244d1d0c48072b8fee7bacc",
@@ -727,11 +735,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:832832a58ecc1b8f33d5e8cb4f7d3db2f5c7fbe922dfee5f958b48fed691501a",
-                "sha256:c47acedfe6495b1c603ed7e93469b26e839cab38db4155113f36f718f8b3dc47"
+                "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed",
+                "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.16"
+            "version": "==2.5.17"
         },
         "idna": {
             "hashes": [
@@ -775,11 +783,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:1893c5b847033cd7a58f6843b04a9349ffb1031bc6588401cadc9adb58da428e",
-                "sha256:5d0675d5f48bf6a95fd517d7b70bcb3b2c5631b2069949b5c2d6e1d7477fb5a0"
+                "sha256:719eac0f1d86706589ee0910d6f785fd4c1ef123ab8e3466b8961c37991d0ef2",
+                "sha256:a9aaefb0cd6f44e3dcaeaafb9222862ae73831f71afd77f465fc83d6199d1888"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.20.2"
+            "version": "==6.21.0"
         },
         "ipython": {
             "hashes": [
@@ -823,19 +831,19 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007",
-                "sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba"
+                "sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011",
+                "sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==8.0.1"
+            "version": "==8.0.2"
         },
         "jupyter-core": {
             "hashes": [
-                "sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae",
-                "sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130"
+                "sha256:1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f",
+                "sha256:4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.1.5"
+            "version": "==5.2.0"
         },
         "keyring": {
             "hashes": [
@@ -1236,6 +1244,17 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.10.0"
         },
+        "pytest-xdist": {
+            "extras": [
+                "psutil"
+            ],
+            "hashes": [
+                "sha256:40fdb8f3544921c5dfcd486ac080ce22870e71d82ced6d2e78fa97c2addd480c",
+                "sha256:70a76f191d8a1d2d6be69fc440cdf85f3e4c03c08b520fd5dc5d338d6cf07d89"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -1548,11 +1567,11 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b",
-                "sha256:a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861"
+                "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8",
+                "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.8.1"
+            "version": "==5.9.0"
         },
         "typer": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ testing =
     pytest-mock~=3.0
     hypothesis~=4.0
     nbmake~=1.3
+    pytest-xdist[psutil]~=3.1
 
 # Dependencies for development (used by Pipenv)
 dev =
@@ -108,8 +109,11 @@ console_scripts =
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this pytest issue.
 addopts =
-    --cov dcqc --cov-report term-missing --cov-report xml
+    --cov "dcqc" --cov-report "term-missing" --cov-report "xml"
     -m "not slow"
+    # For now, the overhead with parallelizing the small number of tests makes
+    # them slower (2.49s vs 1.16s). Uncomment when we have more tests.
+    # --numprocesses "auto"
     --verbose
 norecursedirs =
     dist

--- a/src/dcqc/__main__.py
+++ b/src/dcqc/__main__.py
@@ -1,3 +1,4 @@
-from dcqc.main import app
+if __name__ == "__main__":
+    from dcqc.main import app
 
-app(prog_name="dcqc")
+    app(prog_name="dcqc")

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -69,6 +69,15 @@ class FileType:
         self._registry[name] = self
 
     @classmethod
+    def list_file_types(cls) -> list[FileType]:
+        """Retrieve all available file type objects.
+
+        Returns:
+            The full list of file type objects.
+        """
+        return list(cls._registry.values())
+
+    @classmethod
     def get_file_type(cls, file_type: str) -> FileType:
         """Retrieve file type object based on its name.
 

--- a/src/dcqc/parsers.py
+++ b/src/dcqc/parsers.py
@@ -4,7 +4,7 @@ from collections.abc import Collection, Iterator
 from pathlib import Path
 from typing import Any, Optional, Type, TypeVar, cast
 
-from dcqc.file import File
+from dcqc.file import File, FileType
 from dcqc.mixins import SerializableMixin
 from dcqc.suites.suite_abc import SuiteABC
 from dcqc.target import Target
@@ -85,14 +85,17 @@ class JsonParser:
         suite_classes = SuiteABC.list_subclasses()
         suite_cls_map = {cls.__name__: cls for cls in suite_classes}
 
-        if cls_name == "File":
-            return File
-        elif cls_name == "Target":
+        file_types = FileType.list_file_types()
+        file_types_names = {ft.name.lower() for ft in file_types}
+
+        if cls_name == "Target":
             return Target
         elif cls_name in test_cls_map:
             return test_cls_map[cls_name]
         elif cls_name in suite_cls_map:
             return suite_cls_map[cls_name]
+        elif cls_name.lower() in file_types_names:
+            return File
         else:
             message = f"Type ({cls_name}) is not recognized."
             raise ValueError(message)
@@ -126,7 +129,7 @@ class JsonParser:
         contents = parser.load_json()
 
         if not isinstance(contents, list):
-            message = f"JSON file ({cls.path}) does not contain a list of objects."
+            message = f"JSON file ({parser.path}) does not contain a list of objects."
             raise ValueError(message)
 
         objects = [cls.from_dict(dictionary) for dictionary in contents]

--- a/src/dcqc/reports.py
+++ b/src/dcqc/reports.py
@@ -20,10 +20,10 @@ class JsonReport:
         self._fs: Optional[FS] = None
         self._fs_path: Optional[str] = None
 
+    # TODO: Move towards an FS mixin for these functions
     def _init_fs(self, url) -> tuple[FS, str]:
-        if self._url != url or self._fs is None or self._fs_path is None:
-            self._url = url
-            self._fs, self._fs_path = open_parent_fs(url)
+        self._url = url
+        self._fs, self._fs_path = open_parent_fs(url)
         return self._fs, self._fs_path
 
     def _create_parent_directories(self, url: str):
@@ -61,11 +61,11 @@ class JsonReport:
     # the inputs and outputs: single to single, and many to many.
     @overload
     def generate(self, items: SerializableMixin) -> SerializedObject:
-        ...
+        """"""
 
     @overload
     def generate(self, items: Iterable[SerializableMixin]) -> list[SerializedObject]:
-        ...
+        """"""
 
     def generate(self, items):
         if isinstance(items, Iterable):
@@ -79,13 +79,13 @@ class JsonReport:
     def save(
         self, items: SerializableMixin, url: str, overwrite: bool = False
     ) -> SerializedObject:
-        ...
+        """"""
 
     @overload
     def save(
         self, items: Iterable[SerializableMixin], url: str, overwrite: bool = False
     ) -> list[SerializedObject]:
-        ...
+        """"""
 
     def save(self, items, url: str, overwrite: bool = False):
         report = self.generate(items)

--- a/tests/data/file.json
+++ b/tests/data/file.json
@@ -5,5 +5,5 @@
   },
   "type": "TIFF",
   "name": "test.txt",
-  "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+  "local_path": "tests/data/test.txt"
 }

--- a/tests/data/file.json
+++ b/tests/data/file.json
@@ -1,0 +1,9 @@
+{
+  "url": "tests/data/test.txt",
+  "metadata": {
+    "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
+  },
+  "type": "TIFF",
+  "name": "test.txt",
+  "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+}

--- a/tests/data/generate.py
+++ b/tests/data/generate.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from pathlib import Path
 from typing import Sequence
 
 from dcqc.file import File
@@ -16,7 +17,7 @@ from dcqc.tests import tests
 # Shared values
 data_dir = sys.path[0]
 data_dir = os.path.relpath(data_dir)
-report = JsonReport()
+report = JsonReport(paths_relative_to=Path.cwd())
 
 
 # Shared functions

--- a/tests/data/generate.py
+++ b/tests/data/generate.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from typing import Sequence
 
 from dcqc.file import File
 from dcqc.mixins import SerializableMixin
@@ -19,15 +20,18 @@ report = JsonReport()
 
 
 # Shared functions
-def export(obj: SerializableMixin, filename: str):
+def export(obj: SerializableMixin | Sequence[SerializableMixin], filename: str):
     output_url = os.path.join(data_dir, filename)
     report.save(obj, output_url, overwrite=True)
 
 
-# target.json
+# file.json
 file_url = os.path.join(data_dir, "test.txt")
 metadata = {"file_type": "TIFF", "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"}
 file = File(file_url, metadata)
+export(file, "file.json")
+
+# target.json
 target = Target(file, id="001")
 export(target, "target.json")
 
@@ -43,6 +47,10 @@ export(external_test, "test.external.json")
 computed_test = tests.Md5ChecksumTest(target)
 computed_test.get_status()
 export(computed_test, "test.computed.json")
+
+# tests.json
+test_list = [internal_test, external_test, computed_test]
+export(test_list, "tests.json")
 
 # suite.json
 suite_tests = [internal_test, external_test]

--- a/tests/data/suite.json
+++ b/tests/data/suite.json
@@ -10,8 +10,8 @@
           "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
         },
         "type": "TIFF",
-        "local_path": "tests/data/test.txt",
-        "name": "test.txt"
+        "name": "test.txt",
+        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
       }
     ]
   },

--- a/tests/data/suite.json
+++ b/tests/data/suite.json
@@ -11,7 +11,7 @@
         },
         "type": "TIFF",
         "name": "test.txt",
-        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        "local_path": "tests/data/test.txt"
       }
     ]
   },

--- a/tests/data/target.json
+++ b/tests/data/target.json
@@ -9,7 +9,7 @@
       },
       "type": "TIFF",
       "name": "test.txt",
-      "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+      "local_path": "tests/data/test.txt"
     }
   ]
 }

--- a/tests/data/target.json
+++ b/tests/data/target.json
@@ -8,8 +8,8 @@
         "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
       },
       "type": "TIFF",
-      "local_path": "tests/data/test.txt",
-      "name": "test.txt"
+      "name": "test.txt",
+      "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
     }
   ]
 }

--- a/tests/data/test.computed.json
+++ b/tests/data/test.computed.json
@@ -14,7 +14,7 @@
         },
         "type": "TIFF",
         "name": "test.txt",
-        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        "local_path": "tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/test.computed.json
+++ b/tests/data/test.computed.json
@@ -13,8 +13,8 @@
           "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
         },
         "type": "TIFF",
-        "local_path": "tests/data/test.txt",
-        "name": "test.txt"
+        "name": "test.txt",
+        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/test.external.json
+++ b/tests/data/test.external.json
@@ -14,7 +14,7 @@
         },
         "type": "TIFF",
         "name": "test.txt",
-        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        "local_path": "tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/test.external.json
+++ b/tests/data/test.external.json
@@ -13,8 +13,8 @@
           "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
         },
         "type": "TIFF",
-        "local_path": "tests/data/test.txt",
-        "name": "test.txt"
+        "name": "test.txt",
+        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/test.internal.json
+++ b/tests/data/test.internal.json
@@ -14,7 +14,7 @@
         },
         "type": "TIFF",
         "name": "test.txt",
-        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        "local_path": "tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/test.internal.json
+++ b/tests/data/test.internal.json
@@ -13,8 +13,8 @@
           "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
         },
         "type": "TIFF",
-        "local_path": "tests/data/test.txt",
-        "name": "test.txt"
+        "name": "test.txt",
+        "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
       }
     ]
   }

--- a/tests/data/tests.json
+++ b/tests/data/tests.json
@@ -15,7 +15,7 @@
           },
           "type": "TIFF",
           "name": "test.txt",
-          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+          "local_path": "tests/data/test.txt"
         }
       ]
     }
@@ -36,7 +36,7 @@
           },
           "type": "TIFF",
           "name": "test.txt",
-          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+          "local_path": "tests/data/test.txt"
         }
       ]
     }
@@ -57,7 +57,7 @@
           },
           "type": "TIFF",
           "name": "test.txt",
-          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+          "local_path": "tests/data/test.txt"
         }
       ]
     }

--- a/tests/data/tests.json
+++ b/tests/data/tests.json
@@ -1,0 +1,65 @@
+[
+  {
+    "type": "Md5ChecksumTest",
+    "tier": 1,
+    "is_external_test": false,
+    "status": "pending",
+    "target": {
+      "type": "Target",
+      "id": "001",
+      "files": [
+        {
+          "url": "tests/data/test.txt",
+          "metadata": {
+            "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
+          },
+          "type": "TIFF",
+          "name": "test.txt",
+          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        }
+      ]
+    }
+  },
+  {
+    "type": "LibTiffInfoTest",
+    "tier": 2,
+    "is_external_test": true,
+    "status": "pending",
+    "target": {
+      "type": "Target",
+      "id": "001",
+      "files": [
+        {
+          "url": "tests/data/test.txt",
+          "metadata": {
+            "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
+          },
+          "type": "TIFF",
+          "name": "test.txt",
+          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        }
+      ]
+    }
+  },
+  {
+    "type": "Md5ChecksumTest",
+    "tier": 1,
+    "is_external_test": false,
+    "status": "passed",
+    "target": {
+      "type": "Target",
+      "id": "001",
+      "files": [
+        {
+          "url": "tests/data/test.txt",
+          "metadata": {
+            "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
+          },
+          "type": "TIFF",
+          "name": "test.txt",
+          "local_path": "/Users/bgrande/Repos/py-dcqc/tests/data/test.txt"
+        }
+      ]
+    }
+  }
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,6 +87,8 @@ def test_create_process(get_data, get_output):
 
 def test_compute_test(get_data, get_output):
     input_json = get_data("test.internal.json")
+    print(list(input_json.parent.iterdir()))
+    assert input_json.exists()
     output_path = get_output("compute_test") / "test.json"
     output_path.unlink(missing_ok=True)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,9 @@ def run_command(arguments: list[Any]):
 
 
 def check_command_result(result: Result):
+    if result.exit_code != 0:
+        print(result.stdout)
+        print(result.stderr)
     assert result.exit_code == 0
 
 
@@ -87,8 +90,6 @@ def test_create_process(get_data, get_output):
 
 def test_compute_test(get_data, get_output):
     input_json = get_data("test.internal.json")
-    print(list(input_json.parent.iterdir()))
-    assert input_json.exists()
     output_path = get_output("compute_test") / "test.json"
     output_path.unlink(missing_ok=True)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,7 +20,10 @@ def run_command(arguments: list[Any]):
 def check_command_result(result: Result):
     if result.exit_code != 0:
         print(result.stdout)
-        print(result.stderr)
+        try:
+            print(result.stderr)
+        except ValueError:
+            pass
     assert result.exit_code == 0
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,14 +1,66 @@
 from collections.abc import Generator
 
-from dcqc.parsers import CsvParser
+import pytest
+
+from dcqc.file import File
+from dcqc.mixins import SerializableMixin
+from dcqc.parsers import CsvParser, JsonParser
+from dcqc.suites.suite_abc import SuiteABC
 from dcqc.target import Target
+from dcqc.tests.test_abc import TestABC
 
 
-def test_that_parsing_a_targets_csv_file_yields_qc_targets(get_data):
+def test_that_parsing_a_csv_file_yields_suites(get_data):
     csv_path = get_data("files.csv")
-    parser = CsvParser(csv_path)
-    result = parser.create_targets()
+    csv_parser = CsvParser(csv_path)
+    result = csv_parser.create_suites()
     assert isinstance(result, Generator)
     result = list(result)
     assert len(result) > 1
-    assert all(isinstance(x, Target) for x in result)
+    assert all(isinstance(x, SuiteABC) for x in result)
+
+
+def test_that_parsing_a_csv_file_stages_remote_files(get_data, test_files, mocker):
+    csv_path = get_data("files.csv")
+    csv_parser = CsvParser(csv_path, stage_files=True)
+    mock = mocker.patch.object(csv_parser, "_row_to_file")
+    mock.return_value = test_files["remote"]
+    files = csv_parser.create_files()
+    assert all(file.local_path is not None for _, file in files)
+
+
+def test_that_parsing_a_json_file_must_match_listed_type(get_data):
+    json_path = get_data("file.json")
+    assert JsonParser.parse_object(json_path, File)
+    with pytest.raises(ValueError):
+        JsonParser.parse_object(json_path, Target)
+
+
+def test_for_an_error_when_parsing_an_unrecognized_type():
+    with pytest.raises(ValueError):
+        JsonParser.get_class("foobar")
+
+
+def test_for_an_error_when_parsing_a_dictionary_without_a_type():
+    dictionary = {"foo": "bar"}
+    with pytest.raises(ValueError):
+        JsonParser.from_dict(dictionary)
+
+
+def test_for_an_error_when_parsing_a_list_of_objects_with_parse_object(get_data):
+    json_path = get_data("tests.json")
+    with pytest.raises(ValueError):
+        JsonParser.parse_object(json_path, SerializableMixin)
+
+
+def test_for_an_error_when_parsing_a_single_object_with_parse_objects(get_data):
+    json_path = get_data("target.json")
+    with pytest.raises(ValueError):
+        JsonParser.parse_objects(json_path, SerializableMixin)
+
+
+def test_that_json_parser_can_parse_multiple_objects(get_data):
+    json_path = get_data("tests.json")
+    result = JsonParser.parse_objects(json_path, TestABC)
+    assert len(result) > 0
+    assert isinstance(result[0], TestABC)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -12,7 +12,18 @@ def test_for_error_when_creating_report_if_file_already_exists(get_data, test_fi
 
 
 def test_that_a_single_object_can_be_reported_on(test_files):
-    test_file = test_files["good"]
-    report_url = "mem://report.json"
+    file = test_files["remote"]
+    report_url = "mem://subdir/report.json"
     report = JsonReport()
-    report.save(test_file, report_url, overwrite=True)
+    report.save(file, report_url, overwrite=True)
+
+
+def test_for_an_error_when_saving_to_a_file_with_a_parent_being_a_file(test_files):
+    file = test_files["good"]
+    # Intentionally using the input file in the output path to trigger an error
+    subdir_url = file.local_path.as_posix()
+    report_url = f"{subdir_url}/report.json"
+
+    report = JsonReport()
+    with pytest.raises(NotADirectoryError):
+        report.save(file, report_url)


### PR DESCRIPTION
Alright, here's the final PR to achieve 100% test coverage for `dcqc`. It's worth noting that this coverage doesn't rely on the slower tests (including the end-to-end acceptance test). So, 100% of the code base is tested in under 2 seconds. 🙌 

You'll notice that I tried using `pytest-xdist` to speed up the tests even more, but for now, it slows them down, presumably because of the overhead associated with parallelizing them. Once we have more tests, it'll make more sense to enable parallelized testing.

```
---------- coverage: platform darwin, python 3.11.1-final-0 ----------
Name                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------
src/dcqc/__init__.py               9      0      0      0   100%
src/dcqc/__main__.py               0      0      0      0   100%
src/dcqc/file.py                 163      0     56      0   100%
src/dcqc/main.py                  95      0     32      0   100%
src/dcqc/mixins.py                68      0     34      0   100%
src/dcqc/parsers.py              102      0     48      0   100%
src/dcqc/reports.py               70      0     20      0   100%
src/dcqc/suites/__init__.py        0      0      0      0   100%
src/dcqc/suites/suite_abc.py     169      0     73      0   100%
src/dcqc/suites/suites.py         18      0      0      0   100%
src/dcqc/target.py                43      0     12      0   100%
src/dcqc/tests/__init__.py         0      0      0      0   100%
src/dcqc/tests/test_abc.py       128      0     32      0   100%
src/dcqc/tests/tests.py          100      0     25      0   100%
src/dcqc/utils.py                 20      0      6      0   100%
--------------------------------------------------------------------------
TOTAL                            985      0    338      0   100%
```