### PR TITLE
Copy image to Quay.io to Docker Hub rate limits

### DIFF
--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -121,7 +121,7 @@ class BioFormatsInfoTest(ExternalTestMixin, TestABC):
             path,
         ]
         process = Process(
-            container="openmicroscopy/bftools:latest",
+            container="quay.io/sagebionetworks/bftools:latest",
             command_args=command_args,
         )
         return process
@@ -138,7 +138,7 @@ class OmeXmlSchemaTest(ExternalTestMixin, TestABC):
             path,
         ]
         process = Process(
-            container="openmicroscopy/bftools:latest",
+            container="quay.io/sagebionetworks/bftools:latest",
             command_args=command_args,
         )
         return process

--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -101,7 +101,7 @@ class LibTiffInfoTest(ExternalTestMixin, TestABC):
         path = file.local_path.as_posix()
         command_args = ["tiffinfo", path]
         process = Process(
-            container="quay.io/brunograndephd/libtiff:2.0",
+            container="quay.io/sagebionetworks/libtiff:2.0",
             command_args=command_args,
         )
         return process


### PR DESCRIPTION
This is a short-term fix to the Docker Hub rate limits that we easily run into due to our current infrastructure. 