### PR TITLE
[ORCA-82] Support TSV files for `py-dcqc`

### DIFF
--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -107,6 +107,7 @@ FileType("JSON", (".json",), "format_3464")
 FileType("JSON-LD", (".jsonld",), "format_3749")
 FileType("TIFF", (".tif", ".tiff"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
+FileType("TSV", (".tsv"), "format_3475")
 
 
 # TODO: Leverage post-init function in dataclasses

--- a/src/dcqc/suites/suites.py
+++ b/src/dcqc/suites/suites.py
@@ -28,3 +28,7 @@ class TiffSuite(FileSuite):
 class OmeTiffSuite(TiffSuite):
     file_type = FileType.get_file_type("OME-TIFF")
     add_tests = (tests.OmeXmlSchemaTest, tests.BioFormatsInfoTest)
+
+
+class TSVSuite(FileSuite):
+    file_type = FileType.get_file_type("TSV")

--- a/tests/data/example.tsv
+++ b/tests/data/example.tsv
@@ -1,2 +1,2 @@
-parameter_1	parameter_2	parameter_3
-1	2	3
+foo
+bar

--- a/tests/data/example.tsv
+++ b/tests/data/example.tsv
@@ -1,0 +1,2 @@
+parameter_1	parameter_2	parameter_3
+1	2	3

--- a/tests/data/example.tsv
+++ b/tests/data/example.tsv
@@ -1,2 +1,2 @@
-foo
-bar
+header_1	header_2	header_3
+1	2	3

--- a/tests/data/files.csv
+++ b/tests/data/files.csv
@@ -5,3 +5,4 @@ osfs://test.txt,TXT,definitelynottherightmd5checksum
 syn://syn50555279,TXT,14758f1afd44c09b7992073ccf00b43d
 circuit.tif,TIFF,c7b08f6decb5e7572efbe6074926a843
 example.jsonld,JSON-LD,56bb5f34da6d6df2ade3ac37e25586b7
+example.tsv,TSV,4942c80c8ab0cd7406394af3368332e4

--- a/tests/data/files.csv
+++ b/tests/data/files.csv
@@ -5,4 +5,4 @@ osfs://test.txt,TXT,definitelynottherightmd5checksum
 syn://syn50555279,TXT,14758f1afd44c09b7992073ccf00b43d
 circuit.tif,TIFF,c7b08f6decb5e7572efbe6074926a843
 example.jsonld,JSON-LD,56bb5f34da6d6df2ade3ac37e25586b7
-example.tsv,TSV,4942c80c8ab0cd7406394af3368332e4
+example.tsv,TSV,f47c75614087a8dd938ba4acff252494

--- a/tests/data/staged_targets/example.tsv
+++ b/tests/data/staged_targets/example.tsv
@@ -1,0 +1,1 @@
+/Users/bmacdonald/Development/repos/py-dcqc/tests/data/example.tsv

--- a/tests/data/staged_targets/example.tsv
+++ b/tests/data/staged_targets/example.tsv
@@ -1,1 +1,0 @@
-/Users/bmacdonald/Development/repos/py-dcqc/tests/data/example.tsv


### PR DESCRIPTION
This PR supports TSV file validation following the example in [#12](https://github.com/Sage-Bionetworks-Workflows/py-dcqc/pull/12). The `TSVSuite` class inherits the existing `Md5ChecksumTest` and `FileExtensionTest`. In `tests/data` I have added an `example.tsv` file and a line to `files.csv` with the URL, File Type, and MD5 Checksum for the example file. I tested my changes using the following commands in the CLI:
```
# create targets from files.csv
dcqc create-targets tests/data/files.csv targets
# stage our example.tsv target
dcqc stage-target targets/target-0007.json tsv_target.json staged_targets
# create md5 and file extension test JSON files
dcqc create-tests -rt Md5ChecksumTest,FileExtensionTest targets/target-0007.json test_files
# compute result of Md5ChecksumTest
dcqc compute-test test_files/target-0007.Md5ChecksumTest.json test_results/md5_result.json
# compute result of FileExtensionTest
dcqc compute-test test_files/target-0007.FileExtensionTest.json test_results/file_ext_result.json
# combine test results into a TSV suite JSON file
dcqc create-suite tsv_suite.json test_results/file_ext_result.json test_results/md5_result.json
```