### PR TITLE
[IBCDPE-558] Add `qc-file` CLI command for performing single-file QC

### DIFF
--- a/src/dcqc/main.py
+++ b/src/dcqc/main.py
@@ -184,7 +184,7 @@ def qc_file(
     required_tests: List[str] = required_tests_opt,
     skipped_tests: List[str] = skipped_tests_opt,
 ):
-    """Perform quality control on a single file"""
+    """Run QC tests on a single file (external tests are skipped)"""
     # Interpret empty lists from CLI as None (to auto-generate values)
     required_tests_maybe = required_tests if required_tests else None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,3 +120,17 @@ def test_list_tests():
     args = ["list-tests"]
     result = run_command(args)
     check_command_result(result)
+
+
+def test_qc_file(get_data):
+    tiff_path = get_data("circuit.tif")
+    args = [
+        "qc-file",
+        "-t",
+        "TIFF",
+        "-m",
+        '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
+        tiff_path,
+    ]
+    result = run_command(args)
+    check_command_result(result)


### PR DESCRIPTION
This PR introduces a simple command for performing QC on a single file. It skips all external tests for simplicity. This command is mainly intended for testing and demonstration purposes. In practice, we expect users to use `nf-dcqc`. 

```console
❯ dcqc qc-file -t TIFF -m '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}' ./tests/data/circuit.tif
{
  "type": "TiffSuite",
  "target": {
    "type": "Target",
    "id": null,
    "files": [
      {
        "url": "tests/data/circuit.tif",
        "metadata": {
          "md5_checksum": "c7b08f6decb5e7572efbe6074926a843"
        },
        "type": "TIFF",
        "name": "circuit.tif",
        "local_path": "/var/folders/10/vcs16lfs07sddbfz881cvfb40000gq/T/dcqc-staged-k5pb2fnz/circuit.tif"
      }
    ]
  },
  "suite_status": {
    "required_tests": [
      "FileExtensionTest",
      "LibTiffInfoTest",
      "Md5ChecksumTest"
    ],
    "skipped_tests": [
      "LibTiffInfoTest"
    ],
    "status": "passed"
  },
  "tests": [
    {
      "type": "Md5ChecksumTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "LibTiffInfoTest",
      "tier": 2,
      "is_external_test": true,
      "status": "skipped"
    },
    {
      "type": "FileExtensionTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    }
  ]
}
```