### PR TITLE
Fix grep date test

### DIFF
--- a/src/dcqc/tests/tests.py
+++ b/src/dcqc/tests/tests.py
@@ -145,13 +145,12 @@ class GrepDateTest(ExternalTestMixin, TestABC):
         file = self.get_file()
         path = file.local_path.as_posix()
         command_args = [
-            "!"            # negate exit status
-            "grep",
-            "-E",          # extended regular expression
-            "-i",          # case insensitive
-            "-a",          # treat input as text
-            "-q",          # suppress output
-            "'date|time'", # match date or time
+            "!" "grep",  # negate exit status
+            "-E",  # extended regular expression
+            "-i",  # case insensitive
+            "-a",  # treat input as text
+            "-q",  # suppress output
+            "'date|time'",  # match date or time
             path,
         ]
         process = Process(


### PR DESCRIPTION
Amends `GrepDateTest` to
- Negate the exit code such that a match returns exit 1 (test fails) and no match returns exit 0 (test passes)
- Removes `-w` option so that terms such as `<AcquisitionDate>` where the risk term is not a isolated word now match
- Adds `-a` option to explicitly treat binary files as text
- Adds `-q` option to suppress output as is not needed by the test

Note that for TIFF files this only searches within values of Tags where the content is a string, such as `ImageDescription`
We may wish to add an additional test that searches the `DateTime` tag itself.