### PR TITLE
[ORCA-233] Refactor `Target` ahead of multi-file QC tests

### DIFF
--- a/src/dcqc/main.py
+++ b/src/dcqc/main.py
@@ -11,7 +11,7 @@ from dcqc.file import File, FileType
 from dcqc.parsers import CsvParser, JsonParser
 from dcqc.reports import JsonReport
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import BaseTest, ExternalTestMixin
 
 # Make commands optional to allow for `dcqc --version`
@@ -77,7 +77,7 @@ def create_tests(
     required_tests_maybe = required_tests if required_tests else None
     skipped_tests_maybe = skipped_tests if skipped_tests else None
 
-    target = JsonParser.parse_object(input_json, Target)
+    target = JsonParser.parse_object(input_json, SingleTarget)
     suite = SuiteABC.from_target(target, required_tests_maybe, skipped_tests_maybe)
 
     report = JsonReport()
@@ -192,7 +192,7 @@ def qc_file(
     file_metadata = json.loads(metadata)
     file_metadata["file_type"] = file_type
     file = File(input_file.as_posix(), file_metadata)
-    target = Target(file)
+    target = SingleTarget(file)
 
     # Prepare suite (skip all external tests)
     suite = SuiteABC.from_target(target, required_tests_maybe, skipped_tests)

--- a/src/dcqc/mixins.py
+++ b/src/dcqc/mixins.py
@@ -14,7 +14,6 @@ T = TypeVar("T", bound="SerializableMixin")
 
 
 class SerializableMixin(ABC):
-
     # Used to serialize properties in addition to dataclass attributes
     _serialized_properties: ClassVar[list[str]]
     _serialized_properties = list()
@@ -23,7 +22,7 @@ class SerializableMixin(ABC):
     def from_dict_prepare(cls, dictionary: SerializedObject) -> SerializedObject:
         """Validate and prepare dictionary for deserialization."""
         type_ = dictionary.pop("type")
-        if type_ != cls.__name__:
+        if type_ != cls.__name__:  # pragma: no cover
             message = f"Type ({type_}) does not match the class ({cls.__name__})."
             raise ValueError(message)
         return dictionary

--- a/src/dcqc/parsers.py
+++ b/src/dcqc/parsers.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Type, TypeVar, cast
 from dcqc.file import File, FileType
 from dcqc.mixins import SerializableMixin
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import Target
+from dcqc.target import BaseTarget, Target
 from dcqc.tests.base_test import BaseTest
 
 # For context on TypeVar, check out this GitHub PR comment:
@@ -85,11 +85,14 @@ class JsonParser:
         suite_classes = SuiteABC.list_subclasses()
         suite_cls_map = {cls.__name__: cls for cls in suite_classes}
 
+        target_classes = BaseTarget.list_subclasses()
+        target_cls_map = {cls.__name__: cls for cls in target_classes}
+
         file_types = FileType.list_file_types()
         file_types_names = {ft.name.lower() for ft in file_types}
 
-        if cls_name == "Target":
-            return Target
+        if cls_name in target_cls_map:
+            return target_cls_map[cls_name]
         elif cls_name in test_cls_map:
             return test_cls_map[cls_name]
         elif cls_name in suite_cls_map:

--- a/src/dcqc/parsers.py
+++ b/src/dcqc/parsers.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Type, TypeVar, cast
 from dcqc.file import File, FileType
 from dcqc.mixins import SerializableMixin
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import BaseTarget, Target
+from dcqc.target import BaseTarget, SingleTarget
 from dcqc.tests.base_test import BaseTest
 
 # For context on TypeVar, check out this GitHub PR comment:
@@ -45,9 +45,9 @@ class CsvParser:
                 file.stage(destination, overwrite=True)
             yield index, file
 
-    def create_targets(self) -> Iterator[Target]:
+    def create_targets(self) -> Iterator[SingleTarget]:
         for index, file in self.create_files():
-            yield Target(file, id=f"{index:04}")
+            yield SingleTarget(file, id=f"{index:04}")
 
     def create_suites(
         self,

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -8,7 +8,7 @@ from typing import ClassVar, Optional, Type, Union
 
 from dcqc.file import FileType
 from dcqc.mixins import SerializableMixin, SerializedObject
-from dcqc.target import Target
+from dcqc.target import BaseTarget, Target
 from dcqc.tests import BaseTest, TestStatus
 
 
@@ -35,13 +35,13 @@ class SuiteABC(SerializableMixin, ABC):
 
     # Instance attributes
     type: str
-    target: Target
+    target: BaseTarget
     required_tests: set[str]
     skipped_tests: set[str]
 
     def __init__(
         self,
-        target: Target,
+        target: BaseTarget,
         required_tests: Optional[Collection[str]] = None,
         skipped_tests: Optional[Collection[str]] = None,
     ):
@@ -69,7 +69,7 @@ class SuiteABC(SerializableMixin, ABC):
         required_tests: Optional[Collection[str]] = None,
         skipped_tests: Optional[Collection[str]] = None,
     ) -> SuiteABC:
-        """Generate a suite from a target.
+        """Generate a suite from a single-file target.
 
         The suite is selected based on the target file type.
 
@@ -126,6 +126,8 @@ class SuiteABC(SerializableMixin, ABC):
         if not all(representative_target == target for target in targets):
             message = f"Not all tests refer to the same target ({targets})."
             raise ValueError(message)
+        if not isinstance(representative_target, Target):
+            raise ValueError("Can only recreate suite from single-file target.")
         suite = cls.from_target(representative_target, required_tests, skipped_tests)
         suite.tests = suite_tests
 
@@ -279,7 +281,7 @@ class SuiteABC(SerializableMixin, ABC):
         suite_cls = SuiteABC.get_subclass_by_name(suite_cls_name)
 
         target_dict = dictionary["target"]
-        target = Target.from_dict(target_dict)
+        target = BaseTarget.from_dict(target_dict)
 
         required_tests = dictionary["suite_status"]["required_tests"]
         skipped_tests = dictionary["suite_status"]["skipped_tests"]

--- a/src/dcqc/suites/suite_abc.py
+++ b/src/dcqc/suites/suite_abc.py
@@ -3,27 +3,27 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Collection, Sequence
 from copy import deepcopy
-from typing import ClassVar, Optional, Type, Union
+from typing import ClassVar, Generic, Optional, Type, TypeVar, Union
 
 from dcqc.file import FileType
 from dcqc.mixins import SerializableMixin, SerializedObject, SubclassRegistryMixin
 from dcqc.target import BaseTarget, SingleTarget
 from dcqc.tests import BaseTest, TestStatus
 
+Target = TypeVar("Target", bound=BaseTarget)
+
 
 # TODO: Consider the Composite design pattern once
 #       we have higher-level QC suites
-class SuiteABC(SerializableMixin, SubclassRegistryMixin, ABC):
+class SuiteABC(SerializableMixin, SubclassRegistryMixin, ABC, Generic[Target]):
     """Abstract base class for QC test suites.
 
     Args:
-        target (Target): Single- or multi-file target.
-        required_tests (Optional[Collection[str]]):
-            List of tests that must pass for the
+        target: Single- or multi-file target.
+        required_tests: List of tests that must pass for the
             overall suite to pass. Defaults to None,
             which requires tier-1 and tier-2 tests.
-        skipped_tests (Optional[Collection[str]]):
-            List of tests that should not be
+        skipped_tests: List of tests that should not be
             evaluated. Defaults to None.
     """
 
@@ -34,13 +34,13 @@ class SuiteABC(SerializableMixin, SubclassRegistryMixin, ABC):
 
     # Instance attributes
     type: str
-    target: BaseTarget
+    target: Target
     required_tests: set[str]
     skipped_tests: set[str]
 
     def __init__(
         self,
-        target: BaseTarget,
+        target: Target,
         required_tests: Optional[Collection[str]] = None,
         skipped_tests: Optional[Collection[str]] = None,
     ):

--- a/src/dcqc/target.py
+++ b/src/dcqc/target.py
@@ -100,6 +100,10 @@ class SingleTarget(BaseTarget):
         super().__post_init__(file_or_files)
         self.ensure_single_file()
 
+    # While this function makes sense as a pydantic validator,
+    # we can into strange issues with the following test after
+    # switching to @pydantic.dataclasses.dataclass:
+    # test_that_paths_are_unchanged_when_not_using_serialize_paths_relative_to
     def ensure_single_file(self):
         """Ensure that target is only initialized with a single file.
 

--- a/src/dcqc/tests/base_test.py
+++ b/src/dcqc/tests/base_test.py
@@ -9,10 +9,12 @@ from enum import Enum
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
-from typing import ClassVar, Optional
+from typing import ClassVar, Generic, Optional, TypeVar
 
 from dcqc.mixins import SerializableMixin, SerializedObject, SubclassRegistryMixin
 from dcqc.target import BaseTarget
+
+Target = TypeVar("Target", bound=BaseTarget)
 
 
 class TestStatus(Enum):
@@ -23,7 +25,7 @@ class TestStatus(Enum):
 
 
 # TODO: Look into the @typing.final decorator
-class BaseTest(SerializableMixin, SubclassRegistryMixin, ABC):
+class BaseTest(SerializableMixin, SubclassRegistryMixin, ABC, Generic[Target]):
     """Abstract base class for QC tests.
 
     Args:
@@ -44,9 +46,9 @@ class BaseTest(SerializableMixin, SubclassRegistryMixin, ABC):
 
     # Instance attributes
     type: str
-    target: BaseTarget
+    target: Target
 
-    def __init__(self, target: BaseTarget, skip: bool = False):
+    def __init__(self, target: Target, skip: bool = False):
         self.type = self.__class__.__name__
         self.target = target
         self._status = TestStatus.SKIP if skip else TestStatus.NONE

--- a/src/dcqc/tests/bioformats_info_test.py
+++ b/src/dcqc/tests/bioformats_info_test.py
@@ -1,17 +1,19 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class BioFormatsInfoTest(ExternalBaseTest):
     tier = 2
+    target: Target
 
     def generate_process(self) -> Process:
-        file = self.get_file()
+        path = self.target.file.stage()
         command_args = [
             "/opt/bftools/showinf",
             "-nopix",
             "-novalid",
             "-nocore",
-            file.local_path.as_posix(),
+            path,
         ]
         process = Process(
             container="quay.io/sagebionetworks/bftools:latest",

--- a/src/dcqc/tests/bioformats_info_test.py
+++ b/src/dcqc/tests/bioformats_info_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class BioFormatsInfoTest(ExternalBaseTest):
     tier = 2
-    target: Target
+    target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()

--- a/src/dcqc/tests/file_extension_test.py
+++ b/src/dcqc/tests/file_extension_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class FileExtensionTest(InternalBaseTest):
     tier = 1
-    target: Target
+    target: SingleTarget
 
     def compute_status(self) -> TestStatus:
         status = TestStatus.PASS

--- a/src/dcqc/tests/file_extension_test.py
+++ b/src/dcqc/tests/file_extension_test.py
@@ -1,13 +1,14 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class FileExtensionTest(InternalBaseTest):
     tier = 1
-    only_one_file_targets = False
+    target: Target
 
     def compute_status(self) -> TestStatus:
         status = TestStatus.PASS
-        for file in self.get_files(staged=False):
+        for file in self.target.files:
             file_type = file.get_file_type()
             file_extensions = file_type.file_extensions
             if not file.name.endswith(file_extensions):

--- a/src/dcqc/tests/grep_date_test.py
+++ b/src/dcqc/tests/grep_date_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class GrepDateTest(ExternalBaseTest):
     tier = 4
-    target: Target
+    target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()

--- a/src/dcqc/tests/grep_date_test.py
+++ b/src/dcqc/tests/grep_date_test.py
@@ -1,12 +1,13 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class GrepDateTest(ExternalBaseTest):
     tier = 4
+    target: Target
 
     def generate_process(self) -> Process:
-        file = self.get_file()
-        path = file.local_path.as_posix()
+        path = self.target.file.stage()
         command_args = [
             "!",  # negate exit status
             "grep",

--- a/src/dcqc/tests/json_load_test.py
+++ b/src/dcqc/tests/json_load_test.py
@@ -1,21 +1,20 @@
 import json
 from pathlib import Path
 
-from dcqc.target import BaseTarget
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class JsonLoadTest(InternalBaseTest):
     tier = 2
-    target: BaseTarget
+    target: SingleTarget
 
     def compute_status(self) -> TestStatus:
-        status = TestStatus.PASS
-        for file in self.target.files:
-            path = file.stage()
-            if not self._can_be_loaded(path):
-                status = TestStatus.FAIL
-                break
+        path = self.target.file.stage()
+        if self._can_be_loaded(path):
+            status = TestStatus.PASS
+        else:
+            status = TestStatus.FAIL
         return status
 
     def _can_be_loaded(self, path: Path) -> bool:

--- a/src/dcqc/tests/json_load_test.py
+++ b/src/dcqc/tests/json_load_test.py
@@ -1,17 +1,19 @@
 import json
 from pathlib import Path
 
+from dcqc.target import BaseTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class JsonLoadTest(InternalBaseTest):
     tier = 2
-    only_one_file_targets = False
+    target: BaseTarget
 
     def compute_status(self) -> TestStatus:
         status = TestStatus.PASS
-        for file in self.get_files():
-            if not self._can_be_loaded(file.local_path):
+        for file in self.target.files:
+            path = file.stage()
+            if not self._can_be_loaded(path):
                 status = TestStatus.FAIL
                 break
         return status

--- a/src/dcqc/tests/jsonld_load_test.py
+++ b/src/dcqc/tests/jsonld_load_test.py
@@ -1,20 +1,19 @@
 from pathlib import Path
 
-from dcqc.target import BaseTarget
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class JsonLdLoadTest(InternalBaseTest):
     tier = 2
-    target: BaseTarget
+    target: SingleTarget
 
     def compute_status(self) -> TestStatus:
-        status = TestStatus.PASS
-        for file in self.target.files:
-            path = file.stage()
-            if not self._can_be_loaded(path):
-                status = TestStatus.FAIL
-                break
+        path = self.target.file.stage()
+        if self._can_be_loaded(path):
+            status = TestStatus.PASS
+        else:
+            status = TestStatus.FAIL
         return status
 
     def _can_be_loaded(self, path: Path) -> bool:

--- a/src/dcqc/tests/jsonld_load_test.py
+++ b/src/dcqc/tests/jsonld_load_test.py
@@ -1,16 +1,18 @@
 from pathlib import Path
 
+from dcqc.target import BaseTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class JsonLdLoadTest(InternalBaseTest):
     tier = 2
-    only_one_file_targets = False
+    target: BaseTarget
 
     def compute_status(self) -> TestStatus:
         status = TestStatus.PASS
-        for file in self.get_files():
-            if not self._can_be_loaded(file.local_path):
+        for file in self.target.files:
+            path = file.stage()
+            if not self._can_be_loaded(path):
                 status = TestStatus.FAIL
                 break
         return status

--- a/src/dcqc/tests/libtiff_info_test.py
+++ b/src/dcqc/tests/libtiff_info_test.py
@@ -1,12 +1,17 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class LibTiffInfoTest(ExternalBaseTest):
     tier = 2
+    target: Target
 
     def generate_process(self) -> Process:
-        file = self.get_file()
-        command_args = ["tiffinfo", file.local_path.as_posix()]
+        path = self.target.file.stage()
+        command_args = [
+            "tiffinfo",
+            path,
+        ]
         process = Process(
             container="quay.io/sagebionetworks/libtiff:2.0",
             command_args=command_args,

--- a/src/dcqc/tests/libtiff_info_test.py
+++ b/src/dcqc/tests/libtiff_info_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class LibTiffInfoTest(ExternalBaseTest):
     tier = 2
-    target: Target
+    target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()

--- a/src/dcqc/tests/md5_checksum_test.py
+++ b/src/dcqc/tests/md5_checksum_test.py
@@ -1,18 +1,20 @@
 import hashlib
 from pathlib import Path
 
+from dcqc.target import BaseTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class Md5ChecksumTest(InternalBaseTest):
     tier = 1
-    only_one_file_targets = False
+    target: BaseTarget
 
     def compute_status(self) -> TestStatus:
         status = TestStatus.PASS
-        for file in self.get_files():
+        for file in self.target.files:
+            path = file.stage()
             expected_md5 = file.get_metadata("md5_checksum")
-            actual_md5 = self._compute_md5_checksum(file.local_path)
+            actual_md5 = self._compute_md5_checksum(path)
             if expected_md5 != actual_md5:
                 status = TestStatus.FAIL
                 break

--- a/src/dcqc/tests/md5_checksum_test.py
+++ b/src/dcqc/tests/md5_checksum_test.py
@@ -1,23 +1,22 @@
 import hashlib
 from pathlib import Path
 
-from dcqc.target import BaseTarget
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import InternalBaseTest, TestStatus
 
 
 class Md5ChecksumTest(InternalBaseTest):
     tier = 1
-    target: BaseTarget
+    target: SingleTarget
 
     def compute_status(self) -> TestStatus:
-        status = TestStatus.PASS
-        for file in self.target.files:
-            path = file.stage()
-            expected_md5 = file.get_metadata("md5_checksum")
-            actual_md5 = self._compute_md5_checksum(path)
-            if expected_md5 != actual_md5:
-                status = TestStatus.FAIL
-                break
+        path = self.target.file.stage()
+        expected_md5 = self.target.file.get_metadata("md5_checksum")
+        actual_md5 = self._compute_md5_checksum(path)
+        if expected_md5 == actual_md5:
+            status = TestStatus.PASS
+        else:
+            status = TestStatus.FAIL
         return status
 
     def _compute_md5_checksum(self, path: Path) -> str:

--- a/src/dcqc/tests/ome_xml_schema_test.py
+++ b/src/dcqc/tests/ome_xml_schema_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class OmeXmlSchemaTest(ExternalBaseTest):
     tier = 2
-    target: Target
+    target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()

--- a/src/dcqc/tests/ome_xml_schema_test.py
+++ b/src/dcqc/tests/ome_xml_schema_test.py
@@ -1,14 +1,16 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class OmeXmlSchemaTest(ExternalBaseTest):
     tier = 2
+    target: Target
 
     def generate_process(self) -> Process:
-        file = self.get_file()
+        path = self.target.file.stage()
         command_args = [
             "/opt/bftools/xmlvalid",
-            file.local_path.as_posix(),
+            path,
         ]
         process = Process(
             container="quay.io/sagebionetworks/bftools:latest",

--- a/src/dcqc/tests/tiff_tag_306_date_time_test.py
+++ b/src/dcqc/tests/tiff_tag_306_date_time_test.py
@@ -1,10 +1,10 @@
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class TiffTag306DateTimeTest(ExternalBaseTest):
     tier = 4
-    target: Target
+    target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()

--- a/src/dcqc/tests/tiff_tag_306_date_time_test.py
+++ b/src/dcqc/tests/tiff_tag_306_date_time_test.py
@@ -1,12 +1,13 @@
+from dcqc.target import Target
 from dcqc.tests.base_test import ExternalBaseTest, Process
 
 
 class TiffTag306DateTimeTest(ExternalBaseTest):
     tier = 4
+    target: Target
 
     def generate_process(self) -> Process:
-        file = self.get_file()
-        path = file.local_path.as_posix()
+        path = self.target.file.stage()
         command_args = [
             "!",  # negate exit status
             "tifftools",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest
 
 from dcqc.file import File
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 
 CNFPATH = Path(__file__).resolve()
 TESTDIR = CNFPATH.parent
@@ -101,7 +101,7 @@ def test_files(get_data):
 def test_targets(test_files):
     test_targets = dict()
     for name, file in test_files.items():
-        test_targets[name] = Target(file)
+        test_targets[name] = SingleTarget(file)
     yield test_targets
 
 

--- a/tests/data/generate.py
+++ b/tests/data/generate.py
@@ -12,7 +12,7 @@ from dcqc.file import File
 from dcqc.mixins import SerializableMixin
 from dcqc.reports import JsonReport
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 
 # Shared values
 data_dir = sys.path[0]
@@ -33,7 +33,7 @@ file = File(file_url, metadata)
 export(file, "file.json")
 
 # target.json
-target = Target(file, id="001")
+target = SingleTarget(file, id="001")
 export(target, "target.json")
 
 # test.internal.json

--- a/tests/data/suite.json
+++ b/tests/data/suite.json
@@ -1,8 +1,6 @@
 {
   "type": "TiffSuite",
   "target": {
-    "type": "Target",
-    "id": "001",
     "files": [
       {
         "url": "tests/data/test.txt",
@@ -13,7 +11,9 @@
         "name": "test.txt",
         "local_path": "tests/data/test.txt"
       }
-    ]
+    ],
+    "id": "001",
+    "type": "SingleTarget"
   },
   "suite_status": {
     "required_tests": [

--- a/tests/data/target.json
+++ b/tests/data/target.json
@@ -1,6 +1,4 @@
 {
-  "type": "Target",
-  "id": "001",
   "files": [
     {
       "url": "tests/data/test.txt",
@@ -11,5 +9,7 @@
       "name": "test.txt",
       "local_path": "tests/data/test.txt"
     }
-  ]
+  ],
+  "id": "001",
+  "type": "SingleTarget"
 }

--- a/tests/data/test.computed.json
+++ b/tests/data/test.computed.json
@@ -4,8 +4,6 @@
   "is_external_test": false,
   "status": "passed",
   "target": {
-    "type": "Target",
-    "id": "001",
     "files": [
       {
         "url": "tests/data/test.txt",
@@ -16,6 +14,8 @@
         "name": "test.txt",
         "local_path": "tests/data/test.txt"
       }
-    ]
+    ],
+    "id": "001",
+    "type": "SingleTarget"
   }
 }

--- a/tests/data/test.external.json
+++ b/tests/data/test.external.json
@@ -4,8 +4,6 @@
   "is_external_test": true,
   "status": "pending",
   "target": {
-    "type": "Target",
-    "id": "001",
     "files": [
       {
         "url": "tests/data/test.txt",
@@ -16,6 +14,8 @@
         "name": "test.txt",
         "local_path": "tests/data/test.txt"
       }
-    ]
+    ],
+    "id": "001",
+    "type": "SingleTarget"
   }
 }

--- a/tests/data/test.internal.json
+++ b/tests/data/test.internal.json
@@ -4,8 +4,6 @@
   "is_external_test": false,
   "status": "pending",
   "target": {
-    "type": "Target",
-    "id": "001",
     "files": [
       {
         "url": "tests/data/test.txt",
@@ -16,6 +14,8 @@
         "name": "test.txt",
         "local_path": "tests/data/test.txt"
       }
-    ]
+    ],
+    "id": "001",
+    "type": "SingleTarget"
   }
 }

--- a/tests/data/tests.json
+++ b/tests/data/tests.json
@@ -5,8 +5,6 @@
     "is_external_test": false,
     "status": "pending",
     "target": {
-      "type": "Target",
-      "id": "001",
       "files": [
         {
           "url": "tests/data/test.txt",
@@ -17,7 +15,9 @@
           "name": "test.txt",
           "local_path": "tests/data/test.txt"
         }
-      ]
+      ],
+      "id": "001",
+      "type": "SingleTarget"
     }
   },
   {
@@ -26,8 +26,6 @@
     "is_external_test": true,
     "status": "pending",
     "target": {
-      "type": "Target",
-      "id": "001",
       "files": [
         {
           "url": "tests/data/test.txt",
@@ -38,7 +36,9 @@
           "name": "test.txt",
           "local_path": "tests/data/test.txt"
         }
-      ]
+      ],
+      "id": "001",
+      "type": "SingleTarget"
     }
   },
   {
@@ -47,8 +47,6 @@
     "is_external_test": false,
     "status": "passed",
     "target": {
-      "type": "Target",
-      "id": "001",
       "files": [
         {
           "url": "tests/data/test.txt",
@@ -59,7 +57,9 @@
           "name": "test.txt",
           "local_path": "tests/data/test.txt"
         }
-      ]
+      ],
+      "id": "001",
+      "type": "SingleTarget"
     }
   }
 ]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,7 +6,7 @@ from dcqc.file import File
 from dcqc.mixins import SerializableMixin
 from dcqc.parsers import CsvParser, JsonParser
 from dcqc.suites.suite_abc import SuiteABC
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests.base_test import BaseTest
 
 
@@ -33,7 +33,7 @@ def test_that_parsing_a_json_file_must_match_listed_type(get_data):
     json_path = get_data("file.json")
     assert JsonParser.parse_object(json_path, File)
     with pytest.raises(ValueError):
-        JsonParser.parse_object(json_path, Target)
+        JsonParser.parse_object(json_path, SingleTarget)
 
 
 def test_for_an_error_when_parsing_an_unrecognized_type():

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -100,19 +100,6 @@ def test_for_an_error_when_building_suite_from_tests_with_diff_targets(test_targ
         SuiteABC.from_tests(tests)
 
 
-# TODO: Enable once multi-file target is implemented
-# def test_for_an_error_when_building_suite_from_tests_with_multifile_target(
-#     test_files,
-# ):
-#     file = test_files["good"]
-#     target = BaseTarget(file, file)
-#     test_1 = FileExtensionTest(target)
-#     test_2 = FileExtensionTest(target)
-#     tests = [test_1, test_2]
-#     with pytest.raises(ValueError):
-#         SuiteABC.from_tests(tests)
-
-
 def test_that_a_suite_will_not_consider_unrequired_tests(test_targets):
     target = test_targets["bad"]
     required_tests = []

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -100,6 +100,19 @@ def test_for_an_error_when_building_suite_from_tests_with_diff_targets(test_targ
         SuiteABC.from_tests(tests)
 
 
+# TODO: Enable once multi-file target is implemented
+# def test_for_an_error_when_building_suite_from_tests_with_multifile_target(
+#     test_files,
+# ):
+#     file = test_files["good"]
+#     target = BaseTarget(file, file)
+#     test_1 = FileExtensionTest(target)
+#     test_2 = FileExtensionTest(target)
+#     tests = [test_1, test_2]
+#     with pytest.raises(ValueError):
+#         SuiteABC.from_tests(tests)
+
+
 def test_that_a_suite_will_not_consider_unrequired_tests(test_targets):
     target = test_targets["bad"]
     required_tests = []

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -25,4 +25,4 @@ def test_for_an_error_when_restoring_a_target_with_a_discordant_type(test_files)
 def test_for_an_error_when_creating_single_file_target_with_two_files(test_files):
     test_file = test_files["good"]
     with pytest.raises(ValueError):
-        SingleTarget(test_file, test_file)
+        SingleTarget([test_file, test_file])

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -22,8 +22,7 @@ def test_for_an_error_when_restoring_a_target_with_a_discordant_type(test_files)
         Target.from_dict(target_1_dict)
 
 
-def test_for_an_error_when_accessing_the_file_type_for_a_multifile_target(test_files):
-    file = test_files["good"]
-    target = Target(file, file)
-    with pytest.raises(NotImplementedError):
-        target.get_file_type()
+def test_for_an_error_when_creating_single_file_target_with_two_files(test_files):
+    test_file = test_files["good"]
+    with pytest.raises(ValueError):
+        Target(test_file, test_file)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,13 +1,13 @@
 import pytest
 
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 
 
 def test_that_a_target_can_be_saved_and_restored_without_changing(test_files):
     test_file = test_files["good"]
-    target_1 = Target(test_file)
+    target_1 = SingleTarget(test_file)
     target_1_dict = target_1.to_dict()
-    target_2 = Target.from_dict(target_1_dict)
+    target_2 = SingleTarget.from_dict(target_1_dict)
     target_2_dict = target_2.to_dict()
     assert target_1 == target_2
     assert target_1_dict == target_2_dict
@@ -15,14 +15,14 @@ def test_that_a_target_can_be_saved_and_restored_without_changing(test_files):
 
 def test_for_an_error_when_restoring_a_target_with_a_discordant_type(test_files):
     test_file = test_files["good"]
-    target_1 = Target(test_file)
+    target_1 = SingleTarget(test_file)
     target_1_dict = target_1.to_dict()
     target_1_dict["type"] = "UnexpectedQcTarget"
     with pytest.raises(ValueError):
-        Target.from_dict(target_1_dict)
+        SingleTarget.from_dict(target_1_dict)
 
 
 def test_for_an_error_when_creating_single_file_target_with_two_files(test_files):
     test_file = test_files["good"]
     with pytest.raises(ValueError):
-        Target(test_file, test_file)
+        SingleTarget(test_file, test_file)

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from dcqc import tests
-from dcqc.target import Target
+from dcqc.target import SingleTarget
 from dcqc.tests import BaseTest, ExternalTestMixin, Process, TestStatus
 
 
@@ -91,7 +91,7 @@ def test_that_the_libtiff_info_test_correctly_interprets_exit_code_0_and_1(
     test_files, mocker
 ):
     tiff_file = test_files["tiff"]
-    target = Target(tiff_file)
+    target = SingleTarget(tiff_file)
     with TemporaryDirectory() as tmp_dir:
         path_0 = Path(tmp_dir, "code_0.txt")
         path_1 = Path(tmp_dir, "code_1.txt")
@@ -184,7 +184,7 @@ def test_that_the_grep_date_test_correctly_interprets_exit_code_0_and_1(
     test_files, mocker
 ):
     tiff_file = test_files["tiff"]
-    target = Target(tiff_file)
+    target = SingleTarget(tiff_file)
     with TemporaryDirectory() as tmp_dir:
         path_0 = Path(tmp_dir, "code_0.txt")
         path_1 = Path(tmp_dir, "code_1.txt")
@@ -222,7 +222,7 @@ def test_that_the_tifftag306datetimetest_correctly_interprets_exit_code_0_and_1(
     test_files, mocker
 ):
     tiff_file = test_files["tiff"]
-    target = Target(tiff_file)
+    target = SingleTarget(tiff_file)
     with TemporaryDirectory() as tmp_dir:
         path_0 = Path(tmp_dir, "code_0.txt")
         path_1 = Path(tmp_dir, "code_1.txt")

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -142,18 +142,6 @@ def test_for_an_error_when_retrieving_a_random_test_by_name():
         BaseTest.get_subclass_by_name("FooBar")
 
 
-def test_for_an_error_when_a_libtiff_info_test_is_given_multiple_files(test_files):
-    tiff_file = test_files["tiff"]
-    target = Target(tiff_file, tiff_file)
-
-    assert not tests.Md5ChecksumTest.only_one_file_targets
-    tests.Md5ChecksumTest(target)
-
-    assert tests.LibTiffInfoTest.only_one_file_targets
-    with pytest.raises(ValueError):
-        tests.LibTiffInfoTest(target)
-
-
 def test_that_process_output_files_can_be_found(get_data):
     std_out = get_data("tiffinfo/std_out.txt")
     std_err = get_data("tiffinfo/std_err.txt")
@@ -221,14 +209,6 @@ def test_that_the_grep_date_test_command_is_produced(test_targets):
     test = tests.GrepDateTest(target)
     process = test.generate_process()
     assert "grep" in process.command
-
-
-def test_for_an_error_when_getting_one_file_from_multi_file_target(test_files):
-    file = test_files["good"]
-    target = Target(file, file)
-    test = tests.FileExtensionTest(target)
-    with pytest.raises(ValueError):
-        test.get_file()
 
 
 def test_that_the_tifftag306datetimetest_command_is_produced(test_targets):


### PR DESCRIPTION
Ahead of implementing a multi-file QC test, I decided to refactor the `Target` class to be a base class with a common interface. I then added a `SingleTarget` subclass with methods/properties that only make sense for single-file targets. Tests can then decide whether to use the general `BaseTarget` interface or the additional methods in the `SingleTarget` interface. 

In this PR, I noticed that I was reusing the same pattern for `list_subclasses()` and `get_subclass_by_name()`, so I created another mixin class (`SubclassRegistryMixin`) to add that "registry" functionality to a base class. 

The number of files changed is high mostly because I renamed the `Target` class to `SingleTarget` to avoid confusion. 