### PR TITLE
[ORCA-236] Adds missing code handling and tests for external tests

### DIFF
--- a/src/dcqc/tests/bioformats_info_test.py
+++ b/src/dcqc/tests/bioformats_info_test.py
@@ -4,16 +4,19 @@ from dcqc.tests.base_test import ExternalBaseTest, Process
 
 class BioFormatsInfoTest(ExternalBaseTest):
     tier = 2
+    pass_code = "0"
     target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()
+        string_path = self._short_string_path(path, "dcqc-staged-")
+
         command_args = [
             "/opt/bftools/showinf",
             "-nopix",
             "-novalid",
             "-nocore",
-            path,
+            string_path,
         ]
         process = Process(
             container="quay.io/sagebionetworks/bftools:latest",

--- a/src/dcqc/tests/ome_xml_schema_test.py
+++ b/src/dcqc/tests/ome_xml_schema_test.py
@@ -4,13 +4,16 @@ from dcqc.tests.base_test import ExternalBaseTest, Process
 
 class OmeXmlSchemaTest(ExternalBaseTest):
     tier = 2
+    pass_code = "0"
     target: SingleTarget
 
     def generate_process(self) -> Process:
         path = self.target.file.stage()
+        string_path = self._short_string_path(path, "dcqc-staged-")
+
         command_args = [
             "/opt/bftools/xmlvalid",
-            path,
+            string_path,
         ]
         process = Process(
             container="quay.io/sagebionetworks/bftools:latest",

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -126,11 +126,61 @@ def test_that_the_bioformats_info_test_command_is_produced(test_targets):
     assert "showinf" in process.command
 
 
+def test_that_the_bioformats_info_test_correctly_interprets_exit_code_0_and_1(
+    test_files, mocker
+):
+    # 0 is pass, 1 is fail
+    tiff_file = test_files["tiff"]
+    target = SingleTarget(tiff_file)
+    with TemporaryDirectory() as tmp_dir:
+        path_0 = Path(tmp_dir, "code_0.txt")
+        path_1 = Path(tmp_dir, "code_1.txt")
+        path_0.write_text("0")
+        path_1.write_text("1")
+        pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+        fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+        test = tests.BioFormatsInfoTest(target)
+        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+        test_status = test.get_status()
+        assert test_status == TestStatus.PASS
+
+        test = tests.BioFormatsInfoTest(target)
+        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+        test_status = test.get_status()
+        assert test_status == TestStatus.FAIL
+
+
 def test_that_the_ome_xml_schema_test_command_is_produced(test_targets):
     target = test_targets["tiff"]
     test = tests.OmeXmlSchemaTest(target)
     process = test.generate_process()
     assert "xmlvalid" in process.command
+
+
+def test_that_the_ome_xml_info_test_correctly_interprets_exit_code_0_and_1(
+    test_files, mocker
+):
+    # 0 is pass, 1 is fail
+    tiff_file = test_files["tiff"]
+    target = SingleTarget(tiff_file)
+    with TemporaryDirectory() as tmp_dir:
+        path_0 = Path(tmp_dir, "code_0.txt")
+        path_1 = Path(tmp_dir, "code_1.txt")
+        path_0.write_text("0")
+        path_1.write_text("1")
+        pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+        fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+        test = tests.OmeXmlSchemaTest(target)
+        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+        test_status = test.get_status()
+        assert test_status == TestStatus.PASS
+
+        test = tests.OmeXmlSchemaTest(target)
+        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+        test_status = test.get_status()
+        assert test_status == TestStatus.FAIL
 
 
 def test_that_the_md5_checksum_test_can_be_retrieved_by_name():


### PR DESCRIPTION
This PR is a bug fix in response to @adamjtaylor reporting that the `BioFormatsTest` was not working.

Both the `BioFormatsTest` and `OmeXmlSchemaTest` were not updated along with the other external tests in #35. They were missed due to missing test coverage for their ability to evaluate exit codes.

Both tests are updated to evaluate exit codes the same way the other external tests do, and the missing test coverage is rectified in this PR. 
