### PR TITLE
[ORCA-257] Adds `.svs` and `.scn` and extensions to `TIFF` file type

### DIFF
--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -105,7 +105,7 @@ FileType("*", (), "format_1915")  # To represent all file types
 FileType("TXT", (".txt",), "format_1964")
 FileType("JSON", (".json",), "format_3464")
 FileType("JSON-LD", (".jsonld",), "format_3749")
-FileType("TIFF", (".tif", ".tiff", ".svs"), "format_3591")
+FileType("TIFF", (".tif", ".tiff", ".svs", ".scn"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 FileType("TSV", (".tsv"), "format_3475")
 FileType("BAM", (".bam"), "format_2572")

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -105,7 +105,7 @@ FileType("*", (), "format_1915")  # To represent all file types
 FileType("TXT", (".txt",), "format_1964")
 FileType("JSON", (".json",), "format_3464")
 FileType("JSON-LD", (".jsonld",), "format_3749")
-FileType("TIFF", (".tif", ".tiff"), "format_3591")
+FileType("TIFF", (".tif", ".tiff", ".svs"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 FileType("TSV", (".tsv"), "format_3475")
 FileType("BAM", (".bam"), "format_2572")


### PR DESCRIPTION
This PR adds the `.svs` and `.scn` file extensions to the `TIFF` file type. These changes have been tested both with a `dcqc` run in the `test` configuration and with a `qc-file` command execution where I temporarily changed the `circuit.tif` file within the repository to have the `.svs` and `.scn` extensions (example output below).
```
dcqc qc-file -t TIFF -m '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}' ./tests/data/circuit.svs
{
  "type": "TiffSuite",
  "target": {
    "id": null,
    "files": [
      {
        "url": "tests/data/circuit.svs",
        "metadata": {
          "md5_checksum": "c7b08f6decb5e7572efbe6074926a843"
        },
        "type": "TIFF",
        "name": "circuit.svs",
        "local_path": "/var/folders/sr/3g4hnkfd4ld306tty7kqf1rr0000gr/T/dcqc-staged-_4mndfo1/circuit.svs"
      }
    ],
    "type": "SingleTarget"
  },
  "suite_status": {
    "required_tests": [
      "LibTiffInfoTest",
      "Md5ChecksumTest",
      "FileExtensionTest"
    ],
    "skipped_tests": [
      "LibTiffInfoTest",
      "TiffTag306DateTimeTest",
      "GrepDateTest"
    ],
    "status": "GREEN"
  },
  "tests": [
    {
      "type": "Md5ChecksumTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "GrepDateTest",
      "tier": 4,
      "is_external_test": true,
      "status": "skipped"
    },
    {
      "type": "FileExtensionTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "LibTiffInfoTest",
      "tier": 2,
      "is_external_test": true,
      "status": "skipped"
    },
    {
      "type": "TiffTag306DateTimeTest",
      "tier": 4,
      "is_external_test": true,
      "status": "skipped"
    }
  ]
}
```
