### PR TITLE
[ORCA-262] Adds TXTSuite

### DIFF
--- a/src/dcqc/suites/suites.py
+++ b/src/dcqc/suites/suites.py
@@ -45,3 +45,7 @@ class BAMSuite(FileSuite):
 class FastqSuite(FileSuite):
     file_type = FileType.get_file_type("FASTQ")
     add_tests = (tests.PairedFastqParityTest,)
+
+
+class TXTSuite(FileSuite):
+    file_type = FileType.get_file_type("TXT")


### PR DESCRIPTION
This PR adds support for tests specific to `.txt` files by introducing the `TXTSuite`. This change has been tested with `nf-dcqc` both locally and on [Tower](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/j9JI6PCtNsRZH). Example output using the `qc-file` command:
```
dcqc qc-file -t TXT -m '{"md5_checksum": "14758f1afd44c09b7992073ccf00b43d"}' tests/data/test.txt
{
  "type": "TXTSuite",
  "target": {
    "id": null,
    "files": [
      {
        "url": "tests/data/test.txt",
        "metadata": {
          "md5_checksum": "14758f1afd44c09b7992073ccf00b43d"
        },
        "type": "TXT",
        "name": "test.txt",
        "local_path": "/var/folders/sr/3g4hnkfd4ld306tty7kqf1rr0000gr/T/dcqc-staged-23i95246/test.txt"
      }
    ],
    "type": "SingleTarget"
  },
  "suite_status": {
    "required_tests": [
      "Md5ChecksumTest",
      "FileExtensionTest"
    ],
    "skipped_tests": [],
    "status": "GREEN"
  },
  "tests": [
    {
      "type": "FileExtensionTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "Md5ChecksumTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    }
  ]
}
```