### PR TITLE
[ORCA-263] Adds CSVSuite

### DIFF
--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -109,6 +109,7 @@ FileType("JSON-LD", (".jsonld",), "format_3749")
 FileType("TIFF", (".tif", ".tiff", ".svs", ".scn"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 FileType("TSV", (".tsv"), "format_3475")
+FileType("CSV", (".csv"), "format_3752")
 FileType("BAM", (".bam"), "format_2572")
 FileType("FASTQ", (".fastq", ".fastq.gz", ".fq", ".fq.gz"), "format_1930")
 

--- a/src/dcqc/suites/suites.py
+++ b/src/dcqc/suites/suites.py
@@ -45,3 +45,7 @@ class BAMSuite(FileSuite):
 class FastqSuite(FileSuite):
     file_type = FileType.get_file_type("FASTQ")
     add_tests = (tests.PairedFastqParityTest,)
+
+
+class TXTSuite(FileSuite):
+    file_type = FileType.get_file_type("TXT")

--- a/src/dcqc/suites/suites.py
+++ b/src/dcqc/suites/suites.py
@@ -49,3 +49,7 @@ class FastqSuite(FileSuite):
 
 class TXTSuite(FileSuite):
     file_type = FileType.get_file_type("TXT")
+
+
+class CSVSuite(FileSuite):
+    file_type = FileType.get_file_type("CSV")


### PR DESCRIPTION
This PR adds support for tests specific to `.csv` files by introducing the `CSVSuite`. This change has been tested with `nf-dcqc` both locally and on [Tower](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/j9JI6PCtNsRZH). Example output using the qc-file command:
```
dcqc qc-file -t CSV -m '{"md5_checksum": "ab49a084ccdd0c04879fbbc3ba6b00e8"}' tests/data/small.csv
{
  "type": "CSVSuite",
  "target": {
    "id": null,
    "files": [
      {
        "url": "tests/data/small.csv",
        "metadata": {
          "md5_checksum": "ab49a084ccdd0c04879fbbc3ba6b00e8"
        },
        "type": "CSV",
        "name": "small.csv",
        "local_path": "/var/folders/sr/3g4hnkfd4ld306tty7kqf1rr0000gr/T/dcqc-staged-z5bxrknl/small.csv"
      }
    ],
    "type": "SingleTarget"
  },
  "suite_status": {
    "required_tests": [
      "Md5ChecksumTest",
      "FileExtensionTest"
    ],
    "skipped_tests": [],
    "status": "GREEN"
  },
  "tests": [
    {
      "type": "FileExtensionTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    },
    {
      "type": "Md5ChecksumTest",
      "tier": 1,
      "is_external_test": false,
      "status": "passed"
    }
  ]
}
```