### PR TITLE
Correcting the links in the setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,13 +12,13 @@ license = Apache-2.0
 license_files = LICENSE.txt
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
-url = https://github.com/pyscaffold/pyscaffold/
+url = https://github.com/Sage-Bionetworks-Workflows/py-dcqc
 # Add here related links, for example:
 project_urls =
-    Documentation = https://pyscaffold.org/
-#    Source = https://github.com/pyscaffold/pyscaffold/
+    Source = https://github.com/Sage-Bionetworks-Workflows/py-dcqc
+    Tracker = https://github.com/Sage-Bionetworks-Workflows/py-dcqc/issues
+#    Documentation = https://pyscaffold.org/
 #    Changelog = https://pyscaffold.org/en/latest/changelog.html
-#    Tracker = https://github.com/pyscaffold/pyscaffold/issues
 #    Conda-Forge = https://anaconda.org/conda-forge/pyscaffold
 #    Download = https://pypi.org/project/PyScaffold/#files
 #    Twitter = https://twitter.com/PyScaffold


### PR DESCRIPTION
Problem:
URLs are not linking back to the DCQC github - they're linking out to pyscaffold

Solution:
Update URLs to this GH project