### PR TITLE
[ORCA-289] Refactor External and Internal Testing Unit Tests as Test Classes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,8 +108,8 @@ def test_files(get_data):
         ),
         "wrong_file_type_and_md5_txt": File(txt_path.as_posix(), bad_metadata),
         "good_tiff": File(tiff_path.as_posix(), tiff_metadata),
-        "good_fastq1": File(fastq1_path.as_posix(), fastq_metadata),
-        "good_fastq2": File(fastq2_path.as_posix(), fastq_metadata),
+        "good_fastq": File(fastq1_path.as_posix(), fastq_metadata),
+        "good_compressed_fastq": File(fastq2_path.as_posix(), fastq_metadata),
         "good_jsonld": File(jsonld_path.as_posix(), jsonld_metadata),
         "good_synapse": File(syn_path, good_metadata),
         "dirty_datetime_in_tag_tiff": File(

--- a/tests/test_external_tests.py
+++ b/tests/test_external_tests.py
@@ -8,7 +8,6 @@ import pytest
 
 import docker
 from dcqc import tests
-from dcqc.target import SingleTarget
 from dcqc.tests import BaseTest, ExternalTestMixin, Process, TestStatus
 
 
@@ -103,6 +102,7 @@ class TestLibTiffInfoTest:
 
     @docker_enabled_test
     def test_that_the_libtiff_info_test_exit_code_is_0_when_it_should_be(self):
+        # 0 is pass
         process = self.good_tiff_test.generate_process()
         executor = DockerExecutor(
             process.container, process.command, self.good_tiff_target.file.url
@@ -112,6 +112,7 @@ class TestLibTiffInfoTest:
 
     @docker_enabled_test
     def test_that_the_libtiff_info_test_exit_code_is_1_when_it_should_be(self):
+        # 1 is fail
         process = self.bad_tiff_test.generate_process()
         executor = DockerExecutor(
             process.container, process.command, self.bad_tiff_target.file.url
@@ -120,7 +121,7 @@ class TestLibTiffInfoTest:
         assert executor.exit_code == "1"
 
     def test_that_the_libtiff_info_test_correctly_interprets_exit_code_0_and_1(
-        self, test_files, mocker
+        self, mocker
     ):
         # 0 is pass, 1 is fail
         with TemporaryDirectory() as tmp_dir:
@@ -146,271 +147,293 @@ class TestLibTiffInfoTest:
             assert test_status == TestStatus.FAIL
 
 
-# def test_that_the_bioformats_info_test_command_is_produced(test_targets):
-#     target = test_targets["good_tiff"]
-#     test = tests.BioFormatsInfoTest(target)
-#     process = test.generate_process()
-#     assert "showinf" in process.command
+class TestBioFormatsInfoTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_ome_tiff_target = test_targets["good_ome_tiff"]
+        self.good_ome_tiff_test = tests.BioFormatsInfoTest(self.good_ome_tiff_target)
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.BioFormatsInfoTest(self.good_txt_target)
+
+    def test_that_the_bioformats_info_test_command_is_produced(self):
+        process = self.good_ome_tiff_test.generate_process()
+        assert "showinf" in process.command
+
+    @docker_enabled_test
+    def test_that_the_bioformats_info_test_exit_code_is_0_when_it_should_be(self):
+        # 0 is pass
+        process = self.good_ome_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_ome_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
+
+    @docker_enabled_test
+    def test_that_the_bioformats_info_test_exit_code_is_1_when_it_should_be(self):
+        # 1 is fail
+        process = self.good_txt_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_txt_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
+
+    def test_that_the_bioformats_info_test_correctly_interprets_exit_code_0_and_1(
+        self, mocker
+    ):
+        # 0 is pass, 1 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+            test = tests.BioFormatsInfoTest(self.good_ome_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
+
+            test = tests.BioFormatsInfoTest(self.good_txt_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL
 
 
-# @docker_enabled_test
-# def test_that_the_bioformats_info_test_exit_code_is_0_when_it_should_be(test_files):
-#     one_tiff_file = test_files["good_ome_tiff"]
-#     target = SingleTarget(one_tiff_file)
-#     test = tests.BioFormatsInfoTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "0"
+class TestOmeXmlSchemaTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_ome_tiff_target = test_targets["good_ome_tiff"]
+        self.good_ome_tiff_test = tests.OmeXmlSchemaTest(self.good_ome_tiff_target)
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.OmeXmlSchemaTest(self.good_txt_target)
+
+    def test_that_the_ome_xml_schema_test_command_is_produced(self):
+        process = self.good_ome_tiff_test.generate_process()
+        assert "xmlvalid" in process.command
+
+    @docker_enabled_test
+    def test_that_the_ome_xml_schema_test_exit_code_is_0_when_it_should_be(self):
+        # 0 is pass
+        process = self.good_ome_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_ome_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
+
+    @docker_enabled_test
+    def test_that_the_ome_xml_schema_test_exit_code_is_1_when_it_should_be(self):
+        # 1 is fail
+        process = self.good_txt_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_txt_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
+
+    def test_that_the_ome_xml_info_test_correctly_interprets_exit_code_0_and_1(
+        self, mocker
+    ):
+        # 0 is pass, 1 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+            test = tests.OmeXmlSchemaTest(self.good_ome_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
+
+            test = tests.OmeXmlSchemaTest(self.good_txt_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL
 
 
-# @docker_enabled_test
-# def test_that_the_bioformats_info_test_exit_code_is_1_when_it_should_be(test_files):
-#     one_tiff_file = test_files["good_txt"]
-#     target = SingleTarget(one_tiff_file)
-#     test = tests.BioFormatsInfoTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "1"
+class TestGrepDateTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.GrepDateTest(self.good_txt_target)
+        self.bad_txt_target = test_targets["date_string_txt"]
+        self.bad_txt_test = tests.GrepDateTest(self.bad_txt_target)
+
+    def test_that_the_grep_date_test_command_is_produced(self):
+        process = self.good_txt_test.generate_process()
+        assert "grep" in process.command
+
+    @docker_enabled_test
+    def test_that_the_grep_date_test_exit_code_is_0_when_it_should_be(self):
+        # 0 is fail
+        process = self.bad_txt_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.bad_txt_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
+
+    @docker_enabled_test
+    def test_that_the_grep_date_test_exit_code_is_1_when_it_should_be(self):
+        # 1 is pass
+        process = self.good_txt_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_txt_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
+
+    def test_that_the_grep_date_test_correctly_interprets_exit_code_0_and_1(
+        self, mocker
+    ):
+        # 1 is pass, 0 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+            test = tests.GrepDateTest(self.good_txt_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
+
+            test = tests.GrepDateTest(self.bad_txt_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL
 
 
-# def test_that_the_bioformats_info_test_correctly_interprets_exit_code_0_and_1(
-#     test_files, mocker
-# ):
-#     # 0 is pass, 1 is fail
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     with TemporaryDirectory() as tmp_dir:
-#         path_0 = Path(tmp_dir, "code_0.txt")
-#         path_1 = Path(tmp_dir, "code_1.txt")
-#         path_0.write_text("0")
-#         path_1.write_text("1")
-#         pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-#         fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+class TestTiffTag306DateTimeTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_tiff_target = test_targets["good_tiff"]
+        self.good_tiff_test = tests.TiffTag306DateTimeTest(self.good_tiff_target)
+        self.bad_tiff_target = test_targets["dirty_datetime_in_tag_tiff"]
+        self.bad_tiff_test = tests.TiffTag306DateTimeTest(self.bad_tiff_target)
 
-#         test = tests.BioFormatsInfoTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.PASS
+    def test_that_the_tifftag306datetimetest_command_is_produced(self):
+        process = self.good_tiff_test.generate_process()
+        assert "jq" in process.command
 
-#         test = tests.BioFormatsInfoTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.FAIL
+    @docker_enabled_test
+    def test_that_the_tifftag306datetimetest_exit_code_is_1_when_it_should_be(self):
+        # 1 is pass
+        process = self.good_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
 
+    @docker_enabled_test
+    def test_that_the_tifftag306datetimetest_exit_code_is_0_when_it_should_be(self):
+        process = self.bad_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.bad_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
 
-# def test_that_the_ome_xml_schema_test_command_is_produced(test_targets):
-#     target = test_targets["good_tiff"]
-#     test = tests.OmeXmlSchemaTest(target)
-#     process = test.generate_process()
-#     assert "xmlvalid" in process.command
+    def test_that_the_tifftag306datetimetest_correctly_interprets_exit_code_0_and_1(
+        self, mocker
+    ):
+        # 1 is pass, 0 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
 
+            test = tests.TiffTag306DateTimeTest(self.good_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
 
-# @docker_enabled_test
-# def test_that_the_ome_xml_schema_test_exit_code_is_0_when_it_should_be(test_files):
-#     tiff_file = test_files["good_ome_tiff"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.OmeXmlSchemaTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "0"
-
-
-# @docker_enabled_test
-# def test_that_the_ome_xml_schema_test_exit_code_is_1_when_it_should_be(test_files):
-#     tiff_file = test_files["good_txt"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.OmeXmlSchemaTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "1"
-
-
-# def test_that_the_ome_xml_info_test_correctly_interprets_exit_code_0_and_1(
-#     test_files, mocker
-# ):
-#     # 0 is pass, 1 is fail
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     with TemporaryDirectory() as tmp_dir:
-#         path_0 = Path(tmp_dir, "code_0.txt")
-#         path_1 = Path(tmp_dir, "code_1.txt")
-#         path_0.write_text("0")
-#         path_1.write_text("1")
-#         pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-#         fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-#         test = tests.OmeXmlSchemaTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.PASS
-
-#         test = tests.OmeXmlSchemaTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.FAIL
+            test = tests.TiffTag306DateTimeTest(self.bad_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL
 
 
-# def test_that_the_grep_date_test_command_is_produced(test_targets):
-#     target = test_targets["good_tiff"]
-#     test = tests.GrepDateTest(target)
-#     process = test.generate_process()
-#     assert "grep" in process.command
+class TestTiffDateTimeTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_tiff_target = test_targets["good_tiff"]
+        self.good_tiff_test = tests.TiffDateTimeTest(self.good_tiff_target)
+        self.bad_tiff_target = test_targets["date_in_tag_tiff"]
+        self.bad_tiff_test = tests.TiffDateTimeTest(self.bad_tiff_target)
 
+    def test_that_the_tiffdatetimetest_command_is_produced(self):
+        process = self.good_tiff_test.generate_process()
+        assert "grep" in process.command
 
-# @docker_enabled_test
-# def test_that_the_grep_date_test_exit_code_is_0_when_it_should_be(test_files):
-#     date_file = test_files["date_string_txt"]
-#     target = SingleTarget(date_file)
-#     test = tests.GrepDateTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "0"
+    @docker_enabled_test
+    def test_that_the_tiffdatetimetest_exit_code_is_0_when_it_should_be(self):
+        process = self.bad_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.bad_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
 
+    @docker_enabled_test
+    def test_that_the_tiffdatetimetest_exit_code_is_1_when_it_should_be(self):
+        process = self.good_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
 
-# @docker_enabled_test
-# def test_that_the_grep_date_test_exit_code_is_1_when_it_should_be(test_files):
-#     tiff_file = test_files["good_txt"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.GrepDateTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "1"
+    def test_that_the_tiffdatetimetest_correctly_interprets_exit_code_0_and_1(
+        self, mocker
+    ):
+        # 1 is pass, 0 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
 
+            test = tests.TiffDateTimeTest(self.good_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
 
-# def test_that_the_grep_date_test_correctly_interprets_exit_code_0_and_1(
-#     test_files, mocker
-# ):
-#     # 1 is pass, 0 is fail
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     with TemporaryDirectory() as tmp_dir:
-#         path_0 = Path(tmp_dir, "code_0.txt")
-#         path_1 = Path(tmp_dir, "code_1.txt")
-#         path_0.write_text("0")
-#         path_1.write_text("1")
-#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-#         test = tests.GrepDateTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.PASS
-
-#         test = tests.GrepDateTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.FAIL
-
-
-# def test_that_the_tifftag306datetimetest_command_is_produced(test_targets):
-#     target = test_targets["good_tiff"]
-#     test = tests.TiffTag306DateTimeTest(target)
-#     process = test.generate_process()
-#     assert "jq" in process.command
-
-
-# @docker_enabled_test
-# def test_that_the_tifftag306datetimetest_exit_code_is_1_when_it_should_be(test_files):
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.TiffTag306DateTimeTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "1"
-
-
-# @docker_enabled_test
-# def test_that_the_tifftag306datetimetest_exit_code_is_0_when_it_should_be(test_files):
-#     tiff_file = test_files["dirty_datetime_in_tag_tiff"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.TiffTag306DateTimeTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "0"
-
-
-# def test_that_the_tifftag306datetimetest_correctly_interprets_exit_code_0_and_1(
-#     test_files, mocker
-# ):
-#     # 1 is pass, 0 is fail
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     with TemporaryDirectory() as tmp_dir:
-#         path_0 = Path(tmp_dir, "code_0.txt")
-#         path_1 = Path(tmp_dir, "code_1.txt")
-#         path_0.write_text("0")
-#         path_1.write_text("1")
-#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-#         test = tests.TiffTag306DateTimeTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.PASS
-
-#         test = tests.TiffTag306DateTimeTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.FAIL
-
-
-# def test_that_the_tiffdatetimetest_command_is_produced(test_targets):
-#     target = test_targets["good_tiff"]
-#     test = tests.TiffDateTimeTest(target)
-#     process = test.generate_process()
-#     assert "grep" in process.command
-
-
-# @docker_enabled_test
-# def test_that_the_tiffdatetimetest_exit_code_is_1_when_it_should_be(test_files):
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.TiffDateTimeTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "1"
-
-
-# @docker_enabled_test
-# def test_that_the_tiffdatetimetest_exit_code_is_0_when_it_should_be(test_files):
-#     tiff_file = test_files["date_in_tag_tiff"]
-#     target = SingleTarget(tiff_file)
-#     test = tests.TiffDateTimeTest(target)
-#     process = test.generate_process()
-#     executor = DockerExecutor(process.container, process.command, target.file.url)
-#     executor.execute()
-#     assert executor.exit_code == "0"
-
-
-# def test_that_the_tiffdatetimetest_correctly_interprets_exit_code_0_and_1(
-#     test_files, mocker
-# ):
-#     # 1 is pass, 0 is fail
-#     tiff_file = test_files["good_tiff"]
-#     target = SingleTarget(tiff_file)
-#     with TemporaryDirectory() as tmp_dir:
-#         path_0 = Path(tmp_dir, "code_0.txt")
-#         path_1 = Path(tmp_dir, "code_1.txt")
-#         path_0.write_text("0")
-#         path_1.write_text("1")
-#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-#         test = tests.TiffDateTimeTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.PASS
-
-#         test = tests.TiffDateTimeTest(target)
-#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-#         test_status = test.get_status()
-#         assert test_status == TestStatus.FAIL
+            test = tests.TiffDateTimeTest(self.bad_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL

--- a/tests/test_external_tests.py
+++ b/tests/test_external_tests.py
@@ -89,325 +89,328 @@ class DockerExecutor:
         self.std_err = container.logs(stdout=False, stderr=True).decode("utf-8")
 
 
-def test_that_the_libtiff_info_test_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.LibTiffInfoTest(target)
-    process = test.generate_process()
-    assert "tiffinfo" in process.command
+class TestLibTiffInfoTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_tiff_target = test_targets["good_tiff"]
+        self.good_tiff_test = tests.LibTiffInfoTest(self.good_tiff_target)
+        self.bad_tiff_target = test_targets["wrong_file_type_and_md5_txt"]
+        self.bad_tiff_test = tests.LibTiffInfoTest(self.bad_tiff_target)
+
+    def test_that_the_libtiff_info_test_command_is_produced(self):
+        process = self.good_tiff_test.generate_process()
+        assert "tiffinfo" in process.command
+
+    @docker_enabled_test
+    def test_that_the_libtiff_info_test_exit_code_is_0_when_it_should_be(self):
+        process = self.good_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.good_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "0"
+
+    @docker_enabled_test
+    def test_that_the_libtiff_info_test_exit_code_is_1_when_it_should_be(self):
+        process = self.bad_tiff_test.generate_process()
+        executor = DockerExecutor(
+            process.container, process.command, self.bad_tiff_target.file.url
+        )
+        executor.execute()
+        assert executor.exit_code == "1"
+
+    def test_that_the_libtiff_info_test_correctly_interprets_exit_code_0_and_1(
+        self, test_files, mocker
+    ):
+        # 0 is pass, 1 is fail
+        with TemporaryDirectory() as tmp_dir:
+            path_0 = Path(tmp_dir, "code_0.txt")
+            path_1 = Path(tmp_dir, "code_1.txt")
+            path_0.write_text("0")
+            path_1.write_text("1")
+            pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+            fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+            test = tests.LibTiffInfoTest(self.good_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=pass_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.PASS
+
+            test = tests.LibTiffInfoTest(self.bad_tiff_target)
+            mocker.patch.object(
+                test, "_find_process_outputs", return_value=fail_outputs
+            )
+            test_status = test.get_status()
+            assert test_status == TestStatus.FAIL
 
 
-@docker_enabled_test
-def test_that_the_libtiff_info_test_exit_code_is_0_when_it_should_be(test_files):
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.LibTiffInfoTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
+# def test_that_the_bioformats_info_test_command_is_produced(test_targets):
+#     target = test_targets["good_tiff"]
+#     test = tests.BioFormatsInfoTest(target)
+#     process = test.generate_process()
+#     assert "showinf" in process.command
 
 
-@docker_enabled_test
-def test_that_the_libtiff_info_test_exit_code_is_1_when_it_should_be(test_files):
-    tiff_file = test_files["wrong_file_type_and_md5_txt"]
-    target = SingleTarget(tiff_file)
-    test = tests.LibTiffInfoTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
+# @docker_enabled_test
+# def test_that_the_bioformats_info_test_exit_code_is_0_when_it_should_be(test_files):
+#     one_tiff_file = test_files["good_ome_tiff"]
+#     target = SingleTarget(one_tiff_file)
+#     test = tests.BioFormatsInfoTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "0"
 
 
-def test_that_the_libtiff_info_test_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 0 is pass, 1 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.LibTiffInfoTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.LibTiffInfoTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+# @docker_enabled_test
+# def test_that_the_bioformats_info_test_exit_code_is_1_when_it_should_be(test_files):
+#     one_tiff_file = test_files["good_txt"]
+#     target = SingleTarget(one_tiff_file)
+#     test = tests.BioFormatsInfoTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "1"
 
 
-def test_that_the_bioformats_info_test_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.BioFormatsInfoTest(target)
-    process = test.generate_process()
-    assert "showinf" in process.command
+# def test_that_the_bioformats_info_test_correctly_interprets_exit_code_0_and_1(
+#     test_files, mocker
+# ):
+#     # 0 is pass, 1 is fail
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     with TemporaryDirectory() as tmp_dir:
+#         path_0 = Path(tmp_dir, "code_0.txt")
+#         path_1 = Path(tmp_dir, "code_1.txt")
+#         path_0.write_text("0")
+#         path_1.write_text("1")
+#         pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+#         fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+#         test = tests.BioFormatsInfoTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.PASS
+
+#         test = tests.BioFormatsInfoTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.FAIL
 
 
-@docker_enabled_test
-def test_that_the_bioformats_info_test_exit_code_is_0_when_it_should_be(test_files):
-    one_tiff_file = test_files["good_ome_tiff"]
-    target = SingleTarget(one_tiff_file)
-    test = tests.BioFormatsInfoTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
+# def test_that_the_ome_xml_schema_test_command_is_produced(test_targets):
+#     target = test_targets["good_tiff"]
+#     test = tests.OmeXmlSchemaTest(target)
+#     process = test.generate_process()
+#     assert "xmlvalid" in process.command
 
 
-@docker_enabled_test
-def test_that_the_bioformats_info_test_exit_code_is_1_when_it_should_be(test_files):
-    one_tiff_file = test_files["good_txt"]
-    target = SingleTarget(one_tiff_file)
-    test = tests.BioFormatsInfoTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
+# @docker_enabled_test
+# def test_that_the_ome_xml_schema_test_exit_code_is_0_when_it_should_be(test_files):
+#     tiff_file = test_files["good_ome_tiff"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.OmeXmlSchemaTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "0"
 
 
-def test_that_the_bioformats_info_test_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 0 is pass, 1 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.BioFormatsInfoTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.BioFormatsInfoTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+# @docker_enabled_test
+# def test_that_the_ome_xml_schema_test_exit_code_is_1_when_it_should_be(test_files):
+#     tiff_file = test_files["good_txt"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.OmeXmlSchemaTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "1"
 
 
-def test_that_the_ome_xml_schema_test_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.OmeXmlSchemaTest(target)
-    process = test.generate_process()
-    assert "xmlvalid" in process.command
+# def test_that_the_ome_xml_info_test_correctly_interprets_exit_code_0_and_1(
+#     test_files, mocker
+# ):
+#     # 0 is pass, 1 is fail
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     with TemporaryDirectory() as tmp_dir:
+#         path_0 = Path(tmp_dir, "code_0.txt")
+#         path_1 = Path(tmp_dir, "code_1.txt")
+#         path_0.write_text("0")
+#         path_1.write_text("1")
+#         pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+#         fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+#         test = tests.OmeXmlSchemaTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.PASS
+
+#         test = tests.OmeXmlSchemaTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.FAIL
 
 
-@docker_enabled_test
-def test_that_the_ome_xml_schema_test_exit_code_is_0_when_it_should_be(test_files):
-    tiff_file = test_files["good_ome_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.OmeXmlSchemaTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
+# def test_that_the_grep_date_test_command_is_produced(test_targets):
+#     target = test_targets["good_tiff"]
+#     test = tests.GrepDateTest(target)
+#     process = test.generate_process()
+#     assert "grep" in process.command
 
 
-@docker_enabled_test
-def test_that_the_ome_xml_schema_test_exit_code_is_1_when_it_should_be(test_files):
-    tiff_file = test_files["good_txt"]
-    target = SingleTarget(tiff_file)
-    test = tests.OmeXmlSchemaTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
+# @docker_enabled_test
+# def test_that_the_grep_date_test_exit_code_is_0_when_it_should_be(test_files):
+#     date_file = test_files["date_string_txt"]
+#     target = SingleTarget(date_file)
+#     test = tests.GrepDateTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "0"
 
 
-def test_that_the_ome_xml_info_test_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 0 is pass, 1 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        pass_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        fail_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.OmeXmlSchemaTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.OmeXmlSchemaTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+# @docker_enabled_test
+# def test_that_the_grep_date_test_exit_code_is_1_when_it_should_be(test_files):
+#     tiff_file = test_files["good_txt"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.GrepDateTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "1"
 
 
-def test_that_the_grep_date_test_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.GrepDateTest(target)
-    process = test.generate_process()
-    assert "grep" in process.command
+# def test_that_the_grep_date_test_correctly_interprets_exit_code_0_and_1(
+#     test_files, mocker
+# ):
+#     # 1 is pass, 0 is fail
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     with TemporaryDirectory() as tmp_dir:
+#         path_0 = Path(tmp_dir, "code_0.txt")
+#         path_1 = Path(tmp_dir, "code_1.txt")
+#         path_0.write_text("0")
+#         path_1.write_text("1")
+#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+#         test = tests.GrepDateTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.PASS
+
+#         test = tests.GrepDateTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.FAIL
 
 
-@docker_enabled_test
-def test_that_the_grep_date_test_exit_code_is_0_when_it_should_be(test_files):
-    date_file = test_files["date_string_txt"]
-    target = SingleTarget(date_file)
-    test = tests.GrepDateTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
+# def test_that_the_tifftag306datetimetest_command_is_produced(test_targets):
+#     target = test_targets["good_tiff"]
+#     test = tests.TiffTag306DateTimeTest(target)
+#     process = test.generate_process()
+#     assert "jq" in process.command
 
 
-@docker_enabled_test
-def test_that_the_grep_date_test_exit_code_is_1_when_it_should_be(test_files):
-    tiff_file = test_files["good_txt"]
-    target = SingleTarget(tiff_file)
-    test = tests.GrepDateTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
+# @docker_enabled_test
+# def test_that_the_tifftag306datetimetest_exit_code_is_1_when_it_should_be(test_files):
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.TiffTag306DateTimeTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "1"
 
 
-def test_that_the_grep_date_test_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 1 is pass, 0 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.GrepDateTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.GrepDateTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+# @docker_enabled_test
+# def test_that_the_tifftag306datetimetest_exit_code_is_0_when_it_should_be(test_files):
+#     tiff_file = test_files["dirty_datetime_in_tag_tiff"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.TiffTag306DateTimeTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "0"
 
 
-def test_that_the_tifftag306datetimetest_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.TiffTag306DateTimeTest(target)
-    process = test.generate_process()
-    assert "jq" in process.command
+# def test_that_the_tifftag306datetimetest_correctly_interprets_exit_code_0_and_1(
+#     test_files, mocker
+# ):
+#     # 1 is pass, 0 is fail
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     with TemporaryDirectory() as tmp_dir:
+#         path_0 = Path(tmp_dir, "code_0.txt")
+#         path_1 = Path(tmp_dir, "code_1.txt")
+#         path_0.write_text("0")
+#         path_1.write_text("1")
+#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
+
+#         test = tests.TiffTag306DateTimeTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.PASS
+
+#         test = tests.TiffTag306DateTimeTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.FAIL
 
 
-@docker_enabled_test
-def test_that_the_tifftag306datetimetest_exit_code_is_1_when_it_should_be(test_files):
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.TiffTag306DateTimeTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
+# def test_that_the_tiffdatetimetest_command_is_produced(test_targets):
+#     target = test_targets["good_tiff"]
+#     test = tests.TiffDateTimeTest(target)
+#     process = test.generate_process()
+#     assert "grep" in process.command
 
 
-@docker_enabled_test
-def test_that_the_tifftag306datetimetest_exit_code_is_0_when_it_should_be(test_files):
-    tiff_file = test_files["dirty_datetime_in_tag_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.TiffTag306DateTimeTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
+# @docker_enabled_test
+# def test_that_the_tiffdatetimetest_exit_code_is_1_when_it_should_be(test_files):
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.TiffDateTimeTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "1"
 
 
-def test_that_the_tifftag306datetimetest_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 1 is pass, 0 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.TiffTag306DateTimeTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.TiffTag306DateTimeTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+# @docker_enabled_test
+# def test_that_the_tiffdatetimetest_exit_code_is_0_when_it_should_be(test_files):
+#     tiff_file = test_files["date_in_tag_tiff"]
+#     target = SingleTarget(tiff_file)
+#     test = tests.TiffDateTimeTest(target)
+#     process = test.generate_process()
+#     executor = DockerExecutor(process.container, process.command, target.file.url)
+#     executor.execute()
+#     assert executor.exit_code == "0"
 
 
-def test_that_the_tiffdatetimetest_command_is_produced(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.TiffDateTimeTest(target)
-    process = test.generate_process()
-    assert "grep" in process.command
+# def test_that_the_tiffdatetimetest_correctly_interprets_exit_code_0_and_1(
+#     test_files, mocker
+# ):
+#     # 1 is pass, 0 is fail
+#     tiff_file = test_files["good_tiff"]
+#     target = SingleTarget(tiff_file)
+#     with TemporaryDirectory() as tmp_dir:
+#         path_0 = Path(tmp_dir, "code_0.txt")
+#         path_1 = Path(tmp_dir, "code_1.txt")
+#         path_0.write_text("0")
+#         path_1.write_text("1")
+#         fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
+#         pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
 
+#         test = tests.TiffDateTimeTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.PASS
 
-@docker_enabled_test
-def test_that_the_tiffdatetimetest_exit_code_is_1_when_it_should_be(test_files):
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.TiffDateTimeTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "1"
-
-
-@docker_enabled_test
-def test_that_the_tiffdatetimetest_exit_code_is_0_when_it_should_be(test_files):
-    tiff_file = test_files["date_in_tag_tiff"]
-    target = SingleTarget(tiff_file)
-    test = tests.TiffDateTimeTest(target)
-    process = test.generate_process()
-    executor = DockerExecutor(process.container, process.command, target.file.url)
-    executor.execute()
-    assert executor.exit_code == "0"
-
-
-def test_that_the_tiffdatetimetest_correctly_interprets_exit_code_0_and_1(
-    test_files, mocker
-):
-    # 1 is pass, 0 is fail
-    tiff_file = test_files["good_tiff"]
-    target = SingleTarget(tiff_file)
-    with TemporaryDirectory() as tmp_dir:
-        path_0 = Path(tmp_dir, "code_0.txt")
-        path_1 = Path(tmp_dir, "code_1.txt")
-        path_0.write_text("0")
-        path_1.write_text("1")
-        fail_outputs = {"std_out": path_1, "std_err": path_1, "exit_code": path_0}
-        pass_outputs = {"std_out": path_0, "std_err": path_0, "exit_code": path_1}
-
-        test = tests.TiffDateTimeTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=pass_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.PASS
-
-        test = tests.TiffDateTimeTest(target)
-        mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
-        test_status = test.get_status()
-        assert test_status == TestStatus.FAIL
+#         test = tests.TiffDateTimeTest(target)
+#         mocker.patch.object(test, "_find_process_outputs", return_value=fail_outputs)
+#         test_status = test.get_status()
+#         assert test_status == TestStatus.FAIL

--- a/tests/test_internal_tests.py
+++ b/tests/test_internal_tests.py
@@ -5,81 +5,12 @@ from dcqc.target import PairedTarget
 from dcqc.tests import BaseTest, TestStatus
 
 
-def test_that_the_file_extension_test_works_on_correct_files(test_targets):
-    target = test_targets["good_txt"]
-    test = tests.FileExtensionTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
-
-
-def test_that_the_file_extension_test_works_on_correct_remote_file(test_targets):
-    target = test_targets["remote"]
-    test = tests.FileExtensionTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
-
-
-def test_that_a_tiff_file_with_good_extensions_is_passed(test_targets):
-    target = test_targets["good_tiff"]
-    test = tests.FileExtensionTest(target)
-    assert test.get_status() == TestStatus.PASS
-
-
-def test_that_the_file_extension_test_works_on_incorrect_files(test_targets):
-    target = test_targets["wrong_file_type_and_md5_txt"]
-    test = tests.FileExtensionTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.FAIL
-
-
-def test_that_the_md5_checksum_test_works_on_a_correct_file(test_targets):
-    target = test_targets["good_txt"]
-    test = tests.Md5ChecksumTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
-
-
-def test_that_the_md5_checksum_test_works_on_incorrect_files(test_targets):
-    target = test_targets["wrong_file_type_and_md5_txt"]
-    test = tests.Md5ChecksumTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.FAIL
-
-
-def test_that_the_json_load_test_works_on_a_correct_file(test_targets):
-    target = test_targets["good_jsonld"]
-    test = tests.JsonLoadTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
-
-
-def test_that_the_json_load_test_works_on_incorrect_files(test_targets):
-    target = test_targets["good_txt"]
-    test = tests.JsonLoadTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.FAIL
-
-
-def test_that_the_jsonld_load_test_works_on_a_correct_file(test_targets):
-    target = test_targets["good_jsonld"]
-    test = tests.JsonLdLoadTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
-
-
-def test_that_the_jsonld_load_test_works_on_incorrect_files(test_targets):
-    target = test_targets["good_txt"]
-    test = tests.JsonLdLoadTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.FAIL
-
-
-def test_that_the_md5_checksum_test_can_be_retrieved_by_name():
+def test_that_the_a_test_can_be_correctly_retrieved_by_name():
     test = BaseTest.get_subclass_by_name("Md5ChecksumTest")
     assert test is tests.Md5ChecksumTest
 
 
-def test_for_an_error_when_retrieving_a_random_test_by_name():
+def test_for_an_error_when_retrieving_a_test_that_does_not_exist_by_name():
     with pytest.raises(ValueError):
         BaseTest.get_subclass_by_name("FooBar")
 
@@ -98,32 +29,103 @@ def test_that_an_existing_module_can_be_imported(test_targets):
     assert imported is pytest
 
 
-def test_that_paired_fastq_parity_test_correctly_passes_identical_fastq_files(
-    test_files,
-):
-    fastq1 = test_files["good_fastq1"]
-    target = PairedTarget([fastq1, fastq1])
-    test = tests.PairedFastqParityTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
+class TestFileExtensionTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.FileExtensionTest(self.good_txt_target)
+        self.good_tiff_target = test_targets["good_tiff"]
+        self.good_tiff_test = tests.FileExtensionTest(self.good_tiff_target)
+        self.remote_file_target = test_targets["remote"]
+        self.remote_file_test = tests.FileExtensionTest(self.remote_file_target)
+        self.bad_txt_target = test_targets["wrong_file_type_and_md5_txt"]
+        self.bad_txt_test = tests.FileExtensionTest(self.bad_txt_target)
+
+    def test_that_the_file_extension_test_works_on_correct_files(self):
+        assert self.good_txt_test.get_status() == TestStatus.PASS
+
+    def test_that_the_file_extension_test_works_on_correct_remote_file(self):
+        assert self.remote_file_test.get_status() == TestStatus.PASS
+
+    def test_that_a_tiff_file_with_good_extensions_is_passed(self):
+        assert self.good_tiff_test.get_status() == TestStatus.PASS
+
+    def test_that_the_file_extension_test_works_on_incorrect_files(self):
+        assert self.bad_txt_test.get_status() == TestStatus.FAIL
 
 
-def test_that_paired_fastq_parity_test_correctly_fails_different_fastq_files(
-    test_files,
-):
-    fastq1 = test_files["good_fastq1"]
-    fastq2 = test_files["good_fastq2"]
-    target = PairedTarget([fastq1, fastq2])
-    test = tests.PairedFastqParityTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.FAIL
+class Md5ChecksumTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.Md5ChecksumTest(self.good_txt_target)
+        self.bad_txt_target = test_targets["wrong_file_type_and_md5_txt"]
+        self.bad_txt_test = tests.Md5ChecksumTest(self.bad_txt_target)
+
+    def test_that_the_md5_checksum_test_works_on_a_correct_file(self):
+        assert self.good_txt_test.get_status() == TestStatus.PASS
+
+    def test_that_the_md5_checksum_test_works_on_incorrect_files(self):
+        assert self.bad_txt_test.get_status() == TestStatus.FAIL
 
 
-def test_that_paired_fastq_parity_test_correctly_handles_compressed_fastq_files(
-    test_files,
-):
-    fastq2 = test_files["good_fastq2"]
-    target = PairedTarget([fastq2, fastq2])
-    test = tests.PairedFastqParityTest(target)
-    test_status = test.get_status()
-    assert test_status == TestStatus.PASS
+class TestJsonLoadTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_jsonld_target = test_targets["good_jsonld"]
+        self.good_jsonld_test = tests.JsonLoadTest(self.good_jsonld_target)
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.JsonLoadTest(self.good_txt_target)
+
+    def test_that_the_json_load_test_works_on_a_correct_file(self):
+        assert self.good_jsonld_test.get_status() == TestStatus.PASS
+
+    def test_that_the_json_load_test_works_on_incorrect_files(self):
+        assert self.good_txt_test.get_status() == TestStatus.FAIL
+
+
+class TestJsonLdLoadTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_targets):
+        self.good_jsonld_target = test_targets["good_jsonld"]
+        self.good_jsonld_test = tests.JsonLdLoadTest(self.good_jsonld_target)
+        self.good_txt_target = test_targets["good_txt"]
+        self.good_txt_test = tests.JsonLdLoadTest(self.good_txt_target)
+
+    def test_that_the_jsonld_load_test_works_on_a_correct_file(self):
+        assert self.good_jsonld_test.get_status() == TestStatus.PASS
+
+    def test_that_the_jsonld_load_test_works_on_incorrect_files(self):
+        assert self.good_txt_test.get_status() == TestStatus.FAIL
+
+
+class TestPairedFastqParityTest:
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, test_files):
+        self.fastq1_file = test_files["good_fastq"]
+        self.fastq2_file = test_files["good_compressed_fastq"]
+        self.good_paired_target = PairedTarget([self.fastq1_file, self.fastq1_file])
+        self.good_paired_test = tests.PairedFastqParityTest(self.good_paired_target)
+        self.bad_paired_target = PairedTarget([self.fastq1_file, self.fastq2_file])
+        self.bad_paired_test = tests.PairedFastqParityTest(self.bad_paired_target)
+        self.good_compressed_paired_target = PairedTarget(
+            [self.fastq2_file, self.fastq2_file]
+        )
+        self.good_compressed_paired_test = tests.PairedFastqParityTest(
+            self.good_compressed_paired_target
+        )
+
+    def test_that_paired_fastq_parity_test_correctly_passes_identical_fastq_files(
+        self,
+    ):
+        assert self.good_paired_test.get_status() == TestStatus.PASS
+
+    def test_that_paired_fastq_parity_test_correctly_fails_different_fastq_files(
+        self,
+    ):
+        assert self.bad_paired_test.get_status() == TestStatus.FAIL
+
+    def test_that_paired_fastq_parity_test_correctly_handles_compressed_fastq_files(
+        self,
+    ):
+        assert self.good_compressed_paired_test.get_status() == TestStatus.PASS


### PR DESCRIPTION
**Problem:**

Unit tests for `py-dcqc` Internal and External tests are disorganized, making it more difficult than it needs to be to contribute new DCQC tests.

**Solution:**

Organize all unit tests that specifically evaluate the functionality of DCQC Internal and External tests into test classes to make it clear what unit tests belong together. It should now be simpler for contributors to add new DCQC tests and any needed unit tests.