### PR TITLE
Add support for QPTIFF

### DIFF
--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -106,7 +106,7 @@ FileType("*", (), "format_1915")  # To represent all file types
 FileType("TXT", (".txt",), "format_1964")
 FileType("JSON", (".json",), "format_3464")
 FileType("JSON-LD", (".jsonld",), "format_3749")
-FileType("TIFF", (".tif", ".tiff", ".svs", ".scn"), "format_3591")
+FileType("TIFF", (".tif", ".tiff", ".svs", ".scn", "qptiff"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 FileType("TSV", (".tsv"), "format_3475")
 FileType("CSV", (".csv"), "format_3752")

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -106,7 +106,7 @@ FileType("*", (), "format_1915")  # To represent all file types
 FileType("TXT", (".txt",), "format_1964")
 FileType("JSON", (".json",), "format_3464")
 FileType("JSON-LD", (".jsonld",), "format_3749")
-FileType("TIFF", (".tif", ".tiff", ".svs", ".scn", "qptiff"), "format_3591")
+FileType("TIFF", (".tif", ".tiff", ".svs", ".scn", ".qptiff"), "format_3591")
 FileType("OME-TIFF", (".ome.tif", ".ome.tiff"), "format_3727")
 FileType("TSV", (".tsv"), "format_3475")
 FileType("CSV", (".csv"), "format_3752")

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -24,6 +24,7 @@ from warnings import warn
 from fs.base import FS
 
 from dcqc.mixins import SerializableMixin, SerializedObject
+
 from dcqc.utils import is_url_local, open_parent_fs
 
 

--- a/src/dcqc/file.py
+++ b/src/dcqc/file.py
@@ -24,7 +24,6 @@ from warnings import warn
 from fs.base import FS
 
 from dcqc.mixins import SerializableMixin, SerializedObject
-
 from dcqc.utils import is_url_local, open_parent_fs
 
 


### PR DESCRIPTION
[QPTIFF](https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/perkinelmer-vectra-qptiff.html) is a TIFF-based image format used by PerkinsElmer Vecra mIF and Akoya Phenocycler CODEX instruments. This PR adds basic support for them by including files with the `.qptiff` extension in the TIFF file type.