### PR TITLE
[DPE-1639] Lock down click, typer and setuptools dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,8 @@ For testing purposes, there is a [sample input targets file that is used in the 
 Run QC on a single file:
 
 ```bash
-dcqc qc-file data.csv --file-type csv --metadata '{"author": "John Doe"}' --skipped-tests ""
+dcqc qc-file data.csv --file-type csv --metadata '{"author": "John Doe"}'
 ```
-
-Note you must provide `--skipped-tests ""` as a empty string if you have no tests to skip
 
 ### Creating and Running Test Suites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5"]
+requires = ["setuptools>=80.9.0,<82.0.0", "setuptools_scm[toml]>=5"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,11 +55,12 @@ python_requires = >=3.10, <3.12
 install_requires =
     fs~=2.4
     fs-synapse>=2.0.1
-    typer~=0.7.0
+    typer>=0.16.1 # compatible with click <= 8.2.1
     # TODO: remove click version lock: https://sagebionetworks.jira.com/browse/ORCA-355
     click<=8.2.1
     # TODO: Update requests: https://sagebionetworks.jira.com/browse/ORCA-351
     requests<=2.31.0
+    setuptools~=65.0 # required by fs as it calls pkg_resources, which is part of setuptools
 
 [options.packages.find]
 where = src
@@ -77,7 +78,6 @@ all =
 
 # Dependencies for testing (used by tox and Pipenv)
 testing =
-    setuptools~=65.0
     pytest~=7.0
     pytest-cov~=4.0
     pytest-mock~=3.0

--- a/src/dcqc/main.py
+++ b/src/dcqc/main.py
@@ -198,6 +198,7 @@ def qc_file(
     # Prepare suite (skip all external tests)
     suite = SuiteABC.from_target(target, required_tests_maybe, skipped_tests)
     external_tests = [test.type for test in suite.tests if test.is_external_test]
+    skipped_tests = skipped_tests or []
     skipped_tests += external_tests
     suite = SuiteABC.from_target(target, required_tests_maybe, skipped_tests)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,6 +135,30 @@ def test_qc_file(get_data):
     ]
     result = run_command(args)
     check_command_result(result)
+    
+    
+def test_qc_file_with_skipped_tests(get_data):
+    tiff_path = get_data("circuit.tif")
+    result = run_command([
+        "qc-file",
+        "-t", "TIFF",
+        "-m", '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
+        "--skipped-tests", "Md5ChecksumTest",
+        tiff_path,
+    ])
+    check_command_result(result)
+
+
+def test_qc_file_with_required_tests(get_data):
+    tiff_path = get_data("circuit.tif")
+    result = run_command([
+        "qc-file",
+        "-t", "TIFF",
+        "-m", '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
+        "--required-tests", "Md5ChecksumTest",
+        tiff_path,
+    ])
+    check_command_result(result)
 
 
 def test_qc_file_h5ad(get_data):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,29 +135,39 @@ def test_qc_file(get_data):
     ]
     result = run_command(args)
     check_command_result(result)
-    
-    
+
+
 def test_qc_file_with_skipped_tests(get_data):
     tiff_path = get_data("circuit.tif")
-    result = run_command([
-        "qc-file",
-        "-t", "TIFF",
-        "-m", '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
-        "--skipped-tests", "Md5ChecksumTest",
-        tiff_path,
-    ])
+    result = run_command(
+        [
+            "qc-file",
+            "-t",
+            "TIFF",
+            "-m",
+            '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
+            "--skipped-tests",
+            "Md5ChecksumTest",
+            tiff_path,
+        ]
+    )
     check_command_result(result)
 
 
 def test_qc_file_with_required_tests(get_data):
     tiff_path = get_data("circuit.tif")
-    result = run_command([
-        "qc-file",
-        "-t", "TIFF",
-        "-m", '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
-        "--required-tests", "Md5ChecksumTest",
-        tiff_path,
-    ])
+    result = run_command(
+        [
+            "qc-file",
+            "-t",
+            "TIFF",
+            "-m",
+            '{"md5_checksum": "c7b08f6decb5e7572efbe6074926a843"}',
+            "--required-tests",
+            "Md5ChecksumTest",
+            tiff_path,
+        ]
+    )
     check_command_result(result)
 
 


### PR DESCRIPTION
# **Problem:**
Our current versions for the following dependencies are breaking when running the docker image, as well as installing the environment locally:
- typer = 0.7.0
- click = 8.2.1
- setuptools = 82.0.1

See JIRA Ticket for details on the errors encountered and the detailed solutions.
JIRA Ticket: https://sagebionetworks.jira.com/browse/DPE-1639

**Note** Due to the [failing CI tests](https://github.com/Sage-Bionetworks-Workflows/py-dcqc/actions/runs/24682366210/job/72182867900) which were due to the `skipped_tests` having the possibility of being None, it needed a safer method of being appended with `external_tests` otherwise it failed in the unit tests

# **Solution:**
Lock down dependencies to non-breaking versions:
- typer ~= 16.1.0
- setuptools ~=65.0


# **Testing:**
[X] - Locally run through all of the steps via python virtual env
[X] - Rebuild the docker image with the updated `setup.cfg` and run through all of the steps
[X] - Compared that outputs are the same as a successful DCQC run on nextflow 

Nextflow output with original docker image with no profile (can't find this run anymore, ghost run?)
<img width="1105" height="429" alt="image" src="https://github.com/user-attachments/assets/cd6da369-e484-47c4-b275-d62a682fa338" />

Nextflow output (ran locally) with newly built docker image and `test`, `local` and `docker` profile
<img width="673" height="104" alt="image" src="https://github.com/user-attachments/assets/b8cf3f65-b49d-47b2-b9f8-6cfe27b07940" />

Nextflow output (ran on seqera platform) with old docker image and `test` profile
<img width="1117" height="176" alt="image" src="https://github.com/user-attachments/assets/68b59c52-bde9-4388-a374-15bc4d8a5cba" />

The DCQC results match between the local nextflow run (with the updated docker image) and the nextflow output. It's been difficult to test this out locally without nextflow, I think mainly with the TIFF tests and needing the external tiff docker image to do that part? 


